### PR TITLE
fix: resolve conflict between cypress and jest types

### DIFF
--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "extends": "../tsconfig.json",
+    "include": ["**/*.e2e.ts", "../cypress.config.ts", "../cypress"],
+    "exclude": ["node_modules", "build"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
         // Import non-ES modules as default imports.
         "esModuleInterop": true,
         "jsx": "react",
-        "rootDirs": ["src", "cypress"]
+        "rootDir": "src"
     },
-    "exclude": ["node_modules", "build"]
+    "exclude": ["node_modules", "build", "cypress", "cypress.config.ts"]
 }


### PR DESCRIPTION
Fixes an issue where type declarations for jest and cypress conflict, for example for `expect` which is defined both in jest, and as part of Chai in cypress, so we get type errors in the jest spec files. This solution is based on the dicussions [here](https://stackoverflow.com/questions/58999086/cypress-causing-type-errors-in-jest-assertions) and basically separates the tsconfig file for cypress from the rest of the app.