### PR TITLE
fix: restrict aggregation with additional value types [DHIS2-19549]

### DIFF
--- a/src/pages/dataElements/fields/AggregationTypeField.tsx
+++ b/src/pages/dataElements/fields/AggregationTypeField.tsx
@@ -15,6 +15,15 @@ export const DISABLING_VALUE_TYPES = [
     'USERNAME',
     'FILE_RESOURCE',
     'COORDINATE',
+    'DATE',
+    'DATETIME',
+    'TIME',
+    'ORGANISATION_UNIT',
+    'REFERENCE',
+    'AGE',
+    'URL',
+    'IMAGE',
+    'GEOJSON',
 ]
 
 /**


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-19549

With data elements, certain value types should restrict selection of aggregation type (because they cannot be aggregated). This ticket pointed out that we apparently missed some in our logic. Confirmed with Ameen that these apply for both tracker and aggregate domains.