### PR TITLE
fix: disable focus trap in drawer content [DHIS2-21063]

### DIFF
--- a/src/components/drawer/Drawer.tsx
+++ b/src/components/drawer/Drawer.tsx
@@ -12,6 +12,7 @@ export interface DrawerProps {
     onClose: () => void
     level?: 'primary' | 'secondary'
     header?: React.ReactNode | string
+    disableFocusTrap?: boolean
 }
 
 const DRAWER_PORTAL_ID = 'drawer-portal'
@@ -22,6 +23,7 @@ export const DrawerPanel: React.FC<DrawerProps> = ({
     onClose,
     level = 'primary',
     header,
+    disableFocusTrap = false,
 }) => {
     const globalShellEnabled =
         useSystemSettingsStore(
@@ -47,7 +49,11 @@ export const DrawerPanel: React.FC<DrawerProps> = ({
                 onClick={(e) => e.stopPropagation()}
             >
                 {isOpen && (
-                    <DrawerContents onClose={onClose} header={header}>
+                    <DrawerContents
+                        onClose={onClose}
+                        header={header}
+                        disableFocusTrap={disableFocusTrap}
+                    >
                         {children}
                     </DrawerContents>
                 )}
@@ -60,10 +66,12 @@ const DrawerContents = ({
     children,
     onClose,
     header,
+    disableFocusTrap,
 }: {
     children: React.ReactNode
     onClose: () => void
     header?: React.ReactNode | string
+    disableFocusTrap?: boolean
 }) => {
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => e.key === 'Escape' && onClose()
@@ -76,7 +84,18 @@ const DrawerContents = ({
         ) : (
             header
         )
-    return (
+
+    const content = (
+        <div className={css.drawerContent}>
+            <span tabIndex={0}></span>
+            {headerNode}
+            <div className={css.drawerBody}>{children}</div>
+        </div>
+    )
+
+    return disableFocusTrap ? (
+        content
+    ) : (
         <FocusTrap
             focusTrapOptions={{
                 delayInitialFocus: true,
@@ -86,11 +105,7 @@ const DrawerContents = ({
                 },
             }}
         >
-            <div className={css.drawerContent}>
-                <span tabIndex={0}></span>
-                {headerNode}
-                <div className={css.drawerBody}>{children}</div>
-            </div>
+            {content}
         </FocusTrap>
     )
 }

--- a/src/pages/optionSets/form/optionsList/OptionsListFormContents.tsx
+++ b/src/pages/optionSets/form/optionsList/OptionsListFormContents.tsx
@@ -71,6 +71,7 @@ const OptionListNewOrEdit = () => {
                             : i18n.t('Edit option')}
                     </DrawerHeader>
                 }
+                disableFocusTrap={true}
             >
                 <EditOrNewOptionForm
                     onSubmitted={onSubmitted}

--- a/src/pages/programs/form/trackerProgram/ProgramStagesFormContents.tsx
+++ b/src/pages/programs/form/trackerProgram/ProgramStagesFormContents.tsx
@@ -126,6 +126,7 @@ const ProgramStageListNewOrEdit = () => {
                             : i18n.t('Edit stage')}
                     </DrawerHeader>
                 }
+                disableFocusTrap={true}
             >
                 {stageFormOpen !== undefined && (
                     <EditOrNewStageForm


### PR DESCRIPTION
Fix search bar icon selector for Option set (option) and Program Stages

[DHIS2-21063](https://dhis2.atlassian.net/browse/DHIS2-21063)

_Option set_
<img width="1312" height="959" alt="image" src="https://github.com/user-attachments/assets/42c7c067-57ad-425f-bdca-a2296d9ec5c9" />

_Program stage_
<img width="1312" height="959" alt="image" src="https://github.com/user-attachments/assets/9d29c62e-30e0-4ae0-8024-a86ab222dd93" />

[DHIS2-21063]: https://dhis2.atlassian.net/browse/DHIS2-21063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ