### PR TITLE
fix: data section uniqueness

### DIFF
--- a/src/components/form/fields/NameField.tsx
+++ b/src/components/form/fields/NameField.tsx
@@ -10,17 +10,20 @@ export function NameField({
     helpText,
     modelId,
     caseSensitiveUniqueness = false,
+    customFilterNameUniqueness,
 }: {
     helpText?: string
     schemaSection: SchemaSection
     modelId?: string
     caseSensitiveUniqueness?: boolean
+    customFilterNameUniqueness?: string
 }) {
     const validator = useValidator({
         schemaSection,
         property: 'name',
         modelId,
         caseSensitive: caseSensitiveUniqueness,
+        customFilterUniqueness: customFilterNameUniqueness,
     })
     const schema = useSchema(schemaSection.name)
     const propertyDetails = schema.properties['name']
@@ -34,9 +37,11 @@ export function NameField({
         ),
         caseSensitive: caseSensitiveUniqueness,
     })
-    const uniquenessWarner = propertyDetails.unique
-        ? undefined
-        : checkNameDuplicate
+
+    const uniquenessWarner =
+        propertyDetails.unique || customFilterNameUniqueness
+            ? undefined
+            : checkNameDuplicate
 
     return (
         <FieldRFF name="name" validate={validator}>

--- a/src/components/form/fields/NameFieldWithAdditionalUniquenessConstraint.tsx
+++ b/src/components/form/fields/NameFieldWithAdditionalUniquenessConstraint.tsx
@@ -5,22 +5,25 @@ import { Field as FieldRFF } from 'react-final-form'
 import { SchemaSection, useIsFieldValueUnique, useSchema } from '../../../lib'
 import { useValidator } from '../../../lib/models/useFieldValidators'
 
-export function NameField({
+export function NameFieldWithAdditionalUniquenessConstraint({
     schemaSection,
     helpText,
     modelId,
     caseSensitiveUniqueness = false,
+    additionalNameUniquenessConstraint,
 }: {
     helpText?: string
     schemaSection: SchemaSection
     modelId?: string
     caseSensitiveUniqueness?: boolean
+    additionalNameUniquenessConstraint?: string
 }) {
     const validator = useValidator({
         schemaSection,
         property: 'name',
         modelId,
         caseSensitive: caseSensitiveUniqueness,
+        customFilterUniqueness: additionalNameUniquenessConstraint,
     })
     const schema = useSchema(schemaSection.name)
     const propertyDetails = schema.properties['name']
@@ -34,9 +37,11 @@ export function NameField({
         ),
         caseSensitive: caseSensitiveUniqueness,
     })
-    const uniquenessWarner = propertyDetails.unique
-        ? undefined
-        : checkNameDuplicate
+
+    const uniquenessWarner =
+        propertyDetails.unique || additionalNameUniquenessConstraint
+            ? undefined
+            : checkNameDuplicate
 
     return (
         <FieldRFF name="name" validate={validator}>

--- a/src/components/form/fields/index.ts
+++ b/src/components/form/fields/index.ts
@@ -1,5 +1,6 @@
 export { DefaultIdentifiableFields } from './DefaultIdentifibleFIelds'
 export { NameField } from './NameField'
+export { NameFieldWithAdditionalUniquenessConstraint } from './NameFieldWithAdditionalUniquenessConstraint'
 export { ShortNameField } from './ShortNameField'
 export { CodeField } from './CodeField'
 export { DescriptionField } from './DescriptionField'

--- a/src/lib/models/useFieldValidators.ts
+++ b/src/lib/models/useFieldValidators.ts
@@ -17,14 +17,17 @@ export function useValidator({
     property,
     modelId,
     caseSensitive = false,
+    customFilterUniqueness,
 }: {
     schemaSection: SchemaSection
     property: string
     modelId?: string
     caseSensitive?: boolean
+    customFilterUniqueness?: string
 }) {
     const schema = useSchema(schemaSection.name)
     const propertyDetails = schema.properties[property]
+
     const params = useParams()
     const resolvedModelId = modelId ?? params.id
     const checkIsValueTaken = useIsFieldValueUnique({
@@ -32,6 +35,7 @@ export function useValidator({
         field: property,
         id: resolvedModelId,
         caseSensitive,
+        customFilter: customFilterUniqueness,
     }) as Validator
 
     const validators = useMemo(() => {
@@ -54,9 +58,10 @@ export function useValidator({
             }
         }
 
-        if (propertyDetails.unique) {
+        if (propertyDetails.unique || customFilterUniqueness) {
             validatorsList.push(checkIsValueTaken)
         }
+
         if (propertyDetails.required) {
             validatorsList.push(required)
         }

--- a/src/lib/models/validators/useIsFieldValueUnique.ts
+++ b/src/lib/models/validators/useIsFieldValueUnique.ts
@@ -15,12 +15,14 @@ export function useIsFieldValueUnique({
     model,
     field,
     id,
+    customFilter,
     message,
     caseSensitive = false,
 }: {
     model: string
     field: string
     id?: string
+    customFilter?: string
     message?: string
     caseSensitive?: boolean
 }) {
@@ -39,6 +41,9 @@ export function useIsFieldValueUnique({
                 if (variables.id) {
                     filter.push(`id:ne:${variables.id}`)
                 }
+                if (variables.customFilter) {
+                    filter.push(variables.customFilter)
+                }
 
                 return { pageSize: 1, fields: 'id', filter }
             },
@@ -54,7 +59,7 @@ export function useIsFieldValueUnique({
                 }
 
                 const data = (await engine.query(HAS_FIELD_VALUE_QUERY, {
-                    variables: { field, value, id },
+                    variables: { field, value, id, customFilter },
                 })) as unknown as QueryResponse
 
                 if (data.result.pager.total > 0) {
@@ -66,7 +71,7 @@ export function useIsFieldValueUnique({
                     )
                 }
             }),
-        [field, engine, id, HAS_FIELD_VALUE_QUERY, message]
+        [field, engine, id, HAS_FIELD_VALUE_QUERY, message, customFilter]
     )
 
     // Doing it this way to prevent extra arguments to be passed.

--- a/src/pages/dataSets/form/dataEntryForm/sectionForm/DataSetSectionFormContents.tsx
+++ b/src/pages/dataSets/form/dataEntryForm/sectionForm/DataSetSectionFormContents.tsx
@@ -16,6 +16,7 @@ import {
     useForm,
     useFormState,
 } from 'react-final-form'
+import { useParams } from 'react-router-dom'
 import {
     CodeField,
     DescriptionField,
@@ -66,6 +67,7 @@ export type DataSetDataElementsType = {
 export const DataSetSectionFormContents = ({
     onCancel,
 }: DataSetSectionFormProps) => {
+    const dataSetId = useParams()?.id
     const form = useForm<SectionFormValues>()
     const { submitting, values } = useFormState({
         subscription: { submitting: true, values: true },
@@ -150,6 +152,11 @@ export const DataSetSectionFormContents = ({
                         <NameField
                             schemaSection={dataSetSectionSchemaSection}
                             modelId={values.id}
+                            customFilterNameUniqueness={
+                                dataSetId
+                                    ? `dataSet.id:eq:${dataSetId}`
+                                    : undefined
+                            }
                         />
                     </StandardFormField>
                     <StandardFormField>

--- a/src/pages/dataSets/form/dataEntryForm/sectionForm/DataSetSectionFormContents.tsx
+++ b/src/pages/dataSets/form/dataEntryForm/sectionForm/DataSetSectionFormContents.tsx
@@ -22,7 +22,7 @@ import {
     DescriptionField,
     DrawerFormFooter,
     DrawerLayout,
-    NameField,
+    NameFieldWithAdditionalUniquenessConstraint,
     SectionedFormErrorNotice,
     SectionedFormSection,
     SectionedFormSections,
@@ -149,10 +149,10 @@ export const DataSetSectionFormContents = ({
                         )}
                     </StandardFormSectionDescription>
                     <StandardFormField>
-                        <NameField
+                        <NameFieldWithAdditionalUniquenessConstraint
                             schemaSection={dataSetSectionSchemaSection}
                             modelId={values.id}
-                            customFilterNameUniqueness={
+                            additionalNameUniquenessConstraint={
                                 dataSetId
                                     ? `dataSet.id:eq:${dataSetId}`
                                     : undefined


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-21160

This updates uniqueness check for dataSet.section.name to make validation fail if there is a section of the same name within the given data set. 

**Current**
(Current description below applies to after the recent backend changes to make dataSet.section.name not unique)

_If you try to create a section "Section A" in a data set that already has a "Section A":_
you get a warning in the UI that section name is already in use. You can save, but then the backend will reject.

_If you try to create a section "Section A" in a data set that does not already have a "Section A":_
you get a warning in the UI that section name is already in use. You can save, and this will be accepted by the backend.

**After this change**

_If you try to create a section "Section A" in a data set that already has a "Section A":_
you get a error in the UI that section name is already in use. Saving is disabled (because backend will reject)

_If you try to create a section "Section A" in a data set that does not already have a "Section A":_
There is no warning/error. You can save, and this will be accepted by the backend.