### PR TITLE
fix: cursor in program rule builder expression [DHIS2-21199]

### DIFF
--- a/src/components/ExpressionBuilder/ExpressionBuilder.module.css
+++ b/src/components/ExpressionBuilder/ExpressionBuilder.module.css
@@ -161,6 +161,7 @@ textarea::placeholder {
     text-decoration: none;
     margin-block-end: var(--spacers-dp8);
     font-size: 13px;
+    cursor: default;
 }
 
 /* expression list */


### PR DESCRIPTION
Fix search bar icon selector for Option set (option) and Program Stages

[DHIS2-21199](https://dhis2.atlassian.net/browse/DHIS2-21199)

_Program rule expression_
<img width="1497" height="967" alt="image" src="https://github.com/user-attachments/assets/75055ce3-fbb2-4de7-ab3d-0bf430fc24bf" />


[DHIS2-21199]: https://dhis2.atlassian.net/browse/DHIS2-21199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ