### PR TITLE
fix: cursor in program rules and list view [DHIS2-21351]

### DIFF
--- a/src/components/ExpressionBuilder/ExpressionBuilder.module.css
+++ b/src/components/ExpressionBuilder/ExpressionBuilder.module.css
@@ -145,6 +145,7 @@ textarea::placeholder {
 
 .elementTypePrefix {
     font-weight: 500;
+    cursor: default;
 }
 
 .elementListContainer {

--- a/src/components/sectionList/SectionList.module.css
+++ b/src/components/sectionList/SectionList.module.css
@@ -79,3 +79,7 @@
 .listEmpty {
     text-align: center;
 }
+
+.listRow td pre {
+    cursor: default;
+}


### PR DESCRIPTION
Fix icon pointer cursor for Program rules (expression builder) and options in the list view

[DHIS2-21351](https://dhis2.atlassian.net/browse/DHIS2-21351)

_Program rule expression_
<img width="1438" height="904" alt="image" src="https://github.com/user-attachments/assets/d5e13038-58db-4261-bb57-e85b4e340276" />

_Options in list view_
<img width="1438" height="909" alt="image" src="https://github.com/user-attachments/assets/7c3fafdc-8550-4a20-b9cf-445c96c9b755" />


[DHIS2-21199]: https://dhis2.atlassian.net/browse/DHIS2-21199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-21315]: https://dhis2.atlassian.net/browse/DHIS2-21315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-21351]: https://dhis2.atlassian.net/browse/DHIS2-21351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ