### PR TITLE
fix: update translatable field label

### DIFF
--- a/src/lib/constants/translatedModelProperties.ts
+++ b/src/lib/constants/translatedModelProperties.ts
@@ -97,7 +97,7 @@ const TRANSLATED_PROPERTY: Record<string, string> = {
     enrollmentsLabel: i18n.t('Enrollment label (Plural)'),
     eventsLabel: i18n.t('Event label (Plural)'),
     programStagesLabel: i18n.t('Program stage label (Plural)'),
-    trackedEntityTypesLabel: i18n.t('Names'),
+    trackedEntityTypesLabel: i18n.t('Name (Plural)'),
 }
 
 const camelCaseToSentenceCase = (camelCase: string) =>


### PR DESCRIPTION
Updates the label for trackedEntityTypesLabel to be `Name (Plural)` (see comment https://dhis2.atlassian.net/browse/DHIS2-21010?focusedCommentId=239252)