### PR TITLE
fix(layout): adjust breadcrumb and drawer zindex stack

### DIFF
--- a/src/app/layout/Breadcrumb.module.css
+++ b/src/app/layout/Breadcrumb.module.css
@@ -5,7 +5,7 @@
         0 1px 5px rgba(33, 41, 52, 0.05), 0 0 40px rgba(33, 41, 52, 0.015);
     position: sticky;
     top: 0;
-    z-index: 1;
+    z-index: 10;
 }
 
 .breadcrumbItem {

--- a/src/components/drawer/Drawer.module.css
+++ b/src/components/drawer/Drawer.module.css
@@ -13,7 +13,7 @@
     opacity: 0;
     pointer-events: none;
     transition: opacity 0.3s ease;
-    z-index: 2;
+    z-index: 20;
 }
 
 .drawerOverlay.legacyShell {


### PR DESCRIPTION
Fixes [DHIS2-21300](https://dhis2.atlassian.net/browse/DHIS2-21300).

The `Breadcrumb` originally used `z-index: 1` in order to avoid overlapping the `Drawer` on `z-index: 2`. However, some UI components like Transfer use `z-index: 2`. 

As a quick fix, this PR adjusts the `z-index` for both `Breadcrumb` and `Drawer`. Both are set to higher, but still sensible values. UI `applicationTop` is [set much higher (2000)](https://github.com/dhis2/ui/blob/426f7c99a3d77ff7d19bae60bdbf199e7ae99829/constants/src/layers.js#L2), so these changes do not interfere.

Before: 

<img width="588" height="373" alt="image" src="https://github.com/user-attachments/assets/4724a369-3af2-4fb3-b8a2-25e2622a5bd1" />


After:

<img width="542" height="330" alt="image" src="https://github.com/user-attachments/assets/0d43ff2e-d02f-456b-bdc2-c1d6c9a5da06" />


[DHIS2-21300]: https://dhis2.atlassian.net/browse/DHIS2-21300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ