### PR TITLE
fix(org-unit-list): improve information density, reduce spacing

### DIFF
--- a/src/pages/organisationUnits/list/OrganisationUnitList.module.css
+++ b/src/pages/organisationUnits/list/OrganisationUnitList.module.css
@@ -29,6 +29,13 @@
     padding-block-end: var(--spacers-dp8);
 }
 
+.orgUnitRow td:first-child {
+    padding-left: var(--spacers-dp4);
+}
+
+.selectionCell {
+    padding-inline-end: 0 !important;
+}
 .orgUnitRow.clickable:hover td:nth-child(2) span {
     text-decoration: underline;
 }

--- a/src/pages/organisationUnits/list/OrganisationUnitRow.tsx
+++ b/src/pages/organisationUnits/list/OrganisationUnitRow.tsx
@@ -58,10 +58,10 @@ export const OrganisationUnitRow = ({
                 })}
                 key={row.id}
             >
-                <DataTableCell>
+                <DataTableCell className={css.selectionCell}>
                     <span
                         style={{
-                            paddingLeft: `${row.depth * 2}rem`,
+                            paddingInlineStart: `${row.depth * 1}rem`,
                             display: 'flex',
                         }}
                     >
@@ -92,6 +92,7 @@ export const OrganisationUnitRow = ({
                             <span style={{ width: 26 }} />
                         )}
                         <Checkbox
+                            dense
                             checked={row.getIsSelected()}
                             onChange={({ checked }) =>
                                 row.toggleSelected(checked)


### PR DESCRIPTION
Implements [DHIS2-21311](https://dhis2.atlassian.net/browse/DHIS2-21311)

This PR reduces the spacing of expansion and selection components of the org unit list. It also uses the `dense` checkbox variant as consistent with other lists.

Note: this fix requires a `classname` override on the `DataTableCell` in order to control the padding values. This could theoretically be handled in the UI library, but I'm not sure it warrants a library-wide fix. Open to other opinions though.

Visual comparison:

<img width="1934" height="1982" alt="image" src="https://github.com/user-attachments/assets/998e565b-e6cf-4c2e-bc3d-841712b38019" />


[DHIS2-21311]: https://dhis2.atlassian.net/browse/DHIS2-21311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ