### PR TITLE
fix: allow wrapping of list items [DHIS2-21219]

### DIFF
--- a/src/components/sectionList/SectionList.module.css
+++ b/src/components/sectionList/SectionList.module.css
@@ -53,6 +53,12 @@
     padding-bottom: var(--spacers-dp4);
 }
 
+.listRowText {
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    min-width: 0;
+}
+
 .listRow.active td {
     background-color: var(--colors-grey200);
 }

--- a/src/components/sectionList/SectionListRow.tsx
+++ b/src/components/sectionList/SectionListRow.tsx
@@ -65,7 +65,9 @@ export const SectionListRow = React.memo(function SectionListRow<
                     key={selectedColumn.path}
                     onClick={() => onClick?.(modelData)}
                 >
-                    <pre>{renderColumnValue(selectedColumn, modelData)}</pre>
+                    <span className={css.listRowText}>
+                        {renderColumnValue(selectedColumn, modelData)}
+                    </span>
                 </DataTableCell>
             ))}
             <DataTableCell>{renderActions(modelData)}</DataTableCell>

--- a/src/components/sectionList/detailsPanel/DetailsPanel.module.css
+++ b/src/components/sectionList/detailsPanel/DetailsPanel.module.css
@@ -45,6 +45,9 @@
     font-size: 18px;
     font-weight: 500;
     margin-bottom: var(--spacers-dp12);
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    min-width: 0;
 }
 
 .detailsPanelCloseButton {
@@ -94,6 +97,9 @@
 .detailItemValue {
     font-size: 14px;
     text-align: right;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    min-width: 0;
 }
 
 .detailItemValueButton {


### PR DESCRIPTION
Problem was apparently caused by use of `<pre>` tag, which prevented wrapping. If we use css `white-space: pre-wrap` instead, we get display of internal white space but still get text wrapping within the grid:

(I think with the change, the internal white space might get wrapped, which makes it less visible, but I think that's a very minor issue)

<img width="1154" height="409" alt="image" src="https://github.com/user-attachments/assets/6872bb53-58a7-4820-8381-24bee211f54f" />
