### PR TITLE
fix: cursor in objects in the list view [DHIS2-21351]

### DIFF
--- a/src/components/sectionList/SectionList.module.css
+++ b/src/components/sectionList/SectionList.module.css
@@ -89,3 +89,7 @@
 .listRow td pre {
     cursor: default;
 }
+
+.listRow td span {
+    cursor: default;
+}


### PR DESCRIPTION
Show cursor in elements (Name) of the list view

[DHIS2-21351](https://dhis2.atlassian.net/browse/DHIS2-21351)

<img width="1507" height="653" alt="image" src="https://github.com/user-attachments/assets/6835b245-ae67-464f-aaaf-363b6705e91c" />


[DHIS2-21351]: https://dhis2.atlassian.net/browse/DHIS2-21351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ