### PR TITLE
fix: update workflow node versions

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -19,7 +19,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: yarn
 
             - run: yarn install --frozen-lockfile
@@ -44,7 +44,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: yarn
 
             - run: yarn install --frozen-lockfile
@@ -63,7 +63,7 @@ jobs:
             - uses: actions/checkout@v4
             - uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: yarn
 
             - run: yarn install --frozen-lockfile
@@ -86,7 +86,7 @@ jobs:
     #           uses: actions/checkout@v2
     #         - uses: actions/setup-node@v1
     #           with:
-    #               node-version: 20
+    #               node-version: 24
 
     #         - name: End-to-End tests
     #           uses: cypress-io/github-action@v5
@@ -117,7 +117,7 @@ jobs:
 
             - uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 24
 
             - uses: actions/download-artifact@v4
               with:

--- a/.github/workflows/generate-and-sync-contracts.yml
+++ b/.github/workflows/generate-and-sync-contracts.yml
@@ -23,7 +23,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 24
                   cache: yarn
 
             - name: Install dependencies


### PR DESCRIPTION
updates workflow node versions as node v20 is end of life (ending 2026-04-30). Release action step app-build is not working with node v20 now, which is preventing the release step from executing.