### PR TITLE
fix: update category combo test

### DIFF
--- a/src/pages/categoryCombos/Form.spec.tsx
+++ b/src/pages/categoryCombos/Form.spec.tsx
@@ -267,7 +267,6 @@ describe('Category combos form tests', () => {
                                     displayName: categories[0].displayName,
                                 }),
                             ],
-                            attributeValues: [],
                             dataDimensionType: 'DISAGGREGATION',
                             skipTotal: false,
                         }),


### PR DESCRIPTION
remove one more attributeValues reference in Category Combo Form tests