### PR TITLE
chore: add missing non-default nsseparator

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-04-01T13:52:40.474Z\n"
-"PO-Revision-Date: 2026-04-01T13:52:40.474Z\n"
+"POT-Creation-Date: 2026-05-07T08:04:05.825Z\n"
+"PO-Revision-Date: 2026-05-07T08:04:05.825Z\n"
 
 msgid "schemas"
 msgstr "schemas"
@@ -39,14 +39,26 @@ msgstr "Not found"
 msgid "The page you are looking for does not exist."
 msgstr "The page you are looking for does not exist."
 
+msgid "Duplication not available yet."
+msgstr "Duplication not available yet."
+
+msgid "{{-sectionName}} cannot be duplicated."
+msgstr "{{-sectionName}} cannot be duplicated."
+
+msgid "Edit"
+msgstr "Edit"
+
 msgid "New {{modelName}}"
 msgstr "New {{modelName}}"
 
 msgid "Merge {{modelName}}"
 msgstr "Merge {{modelName}}"
 
-msgid "Edit {{modelName}}"
-msgstr "Edit {{modelName}}"
+msgid "Move organisation units"
+msgstr "Move organisation units"
+
+msgid "Duplicate {{modelName}}"
+msgstr "Duplicate {{modelName}}"
 
 msgid "Metadata Integrity Checks"
 msgstr "Metadata Integrity Checks"
@@ -65,6 +77,9 @@ msgstr "No menu items found for"
 
 msgid "Overview"
 msgstr "Overview"
+
+msgid "Hierarchy operations"
+msgstr "Hierarchy operations"
 
 msgid "Search menu items"
 msgstr "Search menu items"
@@ -466,9 +481,6 @@ msgstr "Custom form"
 msgid "Define a custom form for this {{customFormTarget}} by editing HTML below."
 msgstr "Define a custom form for this {{customFormTarget}} by editing HTML below."
 
-msgid "Edit"
-msgstr "Edit"
-
 msgid "Preview"
 msgstr "Preview"
 
@@ -581,6 +593,16 @@ msgstr "<No value>"
 
 msgid "Set up information for the attributes assigned to {{modelName}}."
 msgstr "Set up information for the attributes assigned to {{modelName}}."
+
+msgid "Duplicating {{- duplicatedModelName}}"
+msgstr "Duplicating {{- duplicatedModelName}}"
+
+msgid ""
+"All values from the original {{-sectionName}} are included. Values that "
+"must be unique need to be updated."
+msgstr ""
+"All values from the original {{-sectionName}} are included. Values that "
+"must be unique need to be updated."
 
 msgid "The default way to aggregate in analytics."
 msgstr "The default way to aggregate in analytics."
@@ -722,6 +744,12 @@ msgstr "undefined"
 
 msgid "Change to {{newValue}}"
 msgstr "Change to {{newValue}}"
+
+msgid "Failed to load data"
+msgstr "Failed to load data"
+
+msgid "Failed to load custom attributes"
+msgstr "Failed to load custom attributes"
 
 msgid "New section"
 msgstr "New section"
@@ -879,9 +907,6 @@ msgstr "An error occurred"
 
 msgid "An error occurred while loading the items."
 msgstr "An error occurred while loading the items."
-
-msgid "{{modelName}} management"
-msgstr "{{modelName}} management"
 
 msgid "Metadata access"
 msgstr "Metadata access"
@@ -1108,6 +1133,9 @@ msgstr "Confirm deletion"
 msgid "Show details"
 msgstr "Show details"
 
+msgid "Duplicate"
+msgstr "Duplicate"
+
 msgid "Sharing settings"
 msgstr "Sharing settings"
 
@@ -1179,6 +1207,9 @@ msgstr "{{number}} selected"
 
 msgid "Merge..."
 msgstr "Merge..."
+
+msgid "Move..."
+msgstr "Move..."
 
 msgid "Choose a Locale to translate from the menu above"
 msgstr "Choose a Locale to translate from the menu above"
@@ -1333,6 +1364,9 @@ msgstr "Validation rule groups"
 msgid "Validation notification"
 msgstr "Validation notification"
 
+msgid "Validation notifications"
+msgstr "Validation notifications"
+
 msgid "Constant"
 msgstr "Constant"
 
@@ -1414,11 +1448,26 @@ msgstr "Predictor group"
 msgid "Predictor groups"
 msgstr "Predictor groups"
 
+msgid "Categories overview"
+msgstr "Categories overview"
+
+msgid "Data elements overview"
+msgstr "Data elements overview"
+
+msgid "Data sets overview"
+msgstr "Data sets overview"
+
 msgid "Indicators and Predictors"
 msgstr "Indicators and Predictors"
 
-msgid "Programs and Tracker"
-msgstr "Programs and Tracker"
+msgid "Organisation units overview"
+msgstr "Organisation units overview"
+
+msgid "Programs overview"
+msgstr "Programs overview"
+
+msgid "Option sets overview"
+msgstr "Option sets overview"
 
 msgid "Validation"
 msgstr "Validation"
@@ -1446,6 +1495,9 @@ msgstr "Program disaggregations"
 
 msgid "You do not have access to edit this item."
 msgstr "You do not have access to edit this item."
+
+msgid "You do not have access to duplicate this item."
+msgstr "You do not have access to duplicate this item."
 
 msgid "You do not have access to delete this item."
 msgstr "You do not have access to delete this item."
@@ -1852,6 +1904,78 @@ msgstr "On complete"
 msgid "On update and insert"
 msgstr "On update and insert"
 
+msgid "Resource tables"
+msgstr "Resource tables"
+
+msgid "Analytics tables"
+msgstr "Analytics tables"
+
+msgid "Data value"
+msgstr "Data value"
+
+msgid "Completeness"
+msgstr "Completeness"
+
+msgid "Completeness target"
+msgstr "Completeness target"
+
+msgid "Organisation unit target"
+msgstr "Organisation unit target"
+
+msgid "Validation result"
+msgstr "Validation result"
+
+msgid "Ownership"
+msgstr "Ownership"
+
+msgid "Tracked entity instance events"
+msgstr "Tracked entity instance events"
+
+msgid "Tracked entity instance enrollments"
+msgstr "Tracked entity instance enrollments"
+
+msgid "Organisation unit structure"
+msgstr "Organisation unit structure"
+
+msgid "Data set organisation unit category"
+msgstr "Data set organisation unit category"
+
+msgid "Category option combo name"
+msgstr "Category option combo name"
+
+msgid "Data element group set structure"
+msgstr "Data element group set structure"
+
+msgid "Indicator group set structure"
+msgstr "Indicator group set structure"
+
+msgid "Organisation unit group set structure"
+msgstr "Organisation unit group set structure"
+
+msgid "Category structure"
+msgstr "Category structure"
+
+msgid "Data element structure"
+msgstr "Data element structure"
+
+msgid "Period structure"
+msgstr "Period structure"
+
+msgid "Date period structure"
+msgstr "Date period structure"
+
+msgid "Data element category option combo"
+msgstr "Data element category option combo"
+
+msgid "Data approval remap level"
+msgstr "Data approval remap level"
+
+msgid "Data approval min level"
+msgstr "Data approval min level"
+
+msgid "Tracked entity instance relationship count"
+msgstr "Tracked entity instance relationship count"
+
 msgid "Data element in newest event in program stage"
 msgstr "Data element in newest event in program stage"
 
@@ -1881,6 +2005,9 @@ msgstr "Attribute category combination"
 
 msgid "Analytics type"
 msgstr "Analytics type"
+
+msgid "Analytics table type"
+msgstr "Analytics table type"
 
 msgid "Bidirectional"
 msgstr "Bidirectional"
@@ -1927,6 +2054,9 @@ msgstr "Relationship name seen from initiating entity"
 msgid "Ignore data approval"
 msgstr "Ignore data approval"
 
+msgid "Phase"
+msgstr "Phase"
+
 msgid "Source type"
 msgstr "Source type"
 
@@ -1941,6 +2071,12 @@ msgstr "Referral"
 
 msgid "Sharing"
 msgstr "Sharing"
+
+msgid "SQL"
+msgstr "SQL"
+
+msgid "Resource table type"
+msgstr "Resource table type"
 
 msgid "Relationship name seen from receiving entity"
 msgstr "Relationship name seen from receiving entity"
@@ -2020,8 +2156,8 @@ msgstr "Event label (Plural)"
 msgid "Program stage label (Plural)"
 msgstr "Program stage label (Plural)"
 
-msgid "Names"
-msgstr "Names"
+msgid "Name (Plural)"
+msgstr "Name (Plural)"
 
 msgid "Unknown error"
 msgstr "Unknown error"
@@ -2284,8 +2420,20 @@ msgstr "Sequential skip count"
 msgid "Organisation unit providing data"
 msgstr "Organisation unit providing data"
 
+msgid "Which resource table"
+msgstr "Which resource table"
+
+msgid "Which analytics table"
+msgstr "Which analytics table"
+
+msgid "An analytics table hook with this table and SQL already exists."
+msgstr "An analytics table hook with this table and SQL already exists."
+
 msgid "Basic information"
 msgstr "Basic information"
+
+msgid "Set up the basic information for this analytics table hook."
+msgstr "Set up the basic information for this analytics table hook."
 
 msgid "Data and options"
 msgstr "Data and options"
@@ -2574,6 +2722,13 @@ msgstr "The numeric value to be used as the constant."
 msgid "Please enter a number"
 msgstr "Please enter a number"
 
+msgid ""
+"An approval level for this organisation unit level and category option "
+"group set combination already exists."
+msgstr ""
+"An approval level for this organisation unit level and category option "
+"group set combination already exists."
+
 msgid "Available data element groups"
 msgstr "Available data element groups"
 
@@ -2828,9 +2983,6 @@ msgstr "Subject"
 
 msgid "Used as template for the message field."
 msgstr "Used as template for the message field."
-
-msgid "{{fieldLabel}} (required)"
-msgstr "{{fieldLabel}} (required)"
 
 msgid "Message"
 msgstr "Message"
@@ -3484,14 +3636,74 @@ msgstr "No indicators available. Remove one from source."
 msgid "What should happen to the source indicators after the merge is complete?"
 msgstr "What should happen to the source indicators after the merge is complete?"
 
+msgid "Set up the basic information for this legend."
+msgstr "Set up the basic information for this legend."
+
+msgid "Legend items"
+msgstr "Legend items"
+
+msgid "Create legend items to define value ranges and associated colors."
+msgstr "Create legend items to define value ranges and associated colors."
+
+msgid "Start value"
+msgstr "Start value"
+
+msgid "End value"
+msgstr "End value"
+
+msgid "Items"
+msgstr "Items"
+
+msgid "Color scale"
+msgstr "Color scale"
+
+msgid "End value must be greater than start value."
+msgstr "End value must be greater than start value."
+
+msgid "Legend items must not overlap."
+msgstr "Legend items must not overlap."
+
+msgid "Legend items must not have gaps."
+msgstr "Legend items must not have gaps."
+
+msgid "Generate a new legend..."
+msgstr "Generate a new legend..."
+
+msgid "Legend generator"
+msgstr "Legend generator"
+
+msgid "Replace existing legend items"
+msgstr "Replace existing legend items"
+
+msgid "Generating new legend items will replace all legend items in the table."
+msgstr "Generating new legend items will replace all legend items in the table."
+
+msgid "Create legend items"
+msgstr "Create legend items"
+
+msgid "Generate a legend"
+msgstr "Generate a legend"
+
+msgid "Generate legend items"
+msgstr "Generate legend items"
+
+msgid "Manually add legend items"
+msgstr "Manually add legend items"
+
+msgid "Add legend item"
+msgstr "Add legend item"
+
+msgid "Change color"
+msgstr "Change color"
+
 msgid "Exit without saving"
 msgstr "Exit without saving"
 
 msgid "Create {{modelName}} "
 msgstr "Create {{modelName}} "
 
-msgid "Country (required)"
-msgstr "Country (required)"
+msgid "Country"
+msgstr "Country"
 
 msgid "Failed to load countries"
 msgstr "Failed to load countries"
@@ -3499,8 +3711,8 @@ msgstr "Failed to load countries"
 msgid "Select a country"
 msgstr "Select a country"
 
-msgid "Language (required)"
-msgstr "Language (required)"
+msgid "Language"
+msgstr "Language"
 
 msgid "Failed to load languages"
 msgstr "Failed to load languages"
@@ -3676,6 +3888,12 @@ msgstr "Choose the organisation units to include in this group."
 msgid "Error saving organisation unit levels"
 msgstr "Error saving organisation unit levels"
 
+msgid "Organisation units successfully moved"
+msgstr "Organisation units successfully moved"
+
+msgid "There was an error moving organisation units: {{orgUnitNames}}"
+msgstr "There was an error moving organisation units: {{orgUnitNames}}"
+
 msgid "Longitude"
 msgstr "Longitude"
 
@@ -3796,6 +4014,28 @@ msgstr "No organisation units available"
 
 msgid "Load more for {{orgUnitName}}"
 msgstr "Load more for {{orgUnitName}}"
+
+msgid ""
+"Choose the organisation units to move and their new position in the "
+"hierarchy. All descendants move with them."
+msgstr ""
+"Choose the organisation units to move and their new position in the "
+"hierarchy. All descendants move with them."
+
+msgid "Move"
+msgstr "Move"
+
+msgid "Can not move an organisation unit to one of its descendants."
+msgstr "Can not move an organisation unit to one of its descendants."
+
+msgid "Organisation units to move"
+msgstr "Organisation units to move"
+
+msgid "Move into"
+msgstr "Move into"
+
+msgid "At least one org unit is required"
+msgstr "At least one org unit is required"
 
 msgid "Metadata management"
 msgstr "Metadata management"
@@ -4217,12 +4457,6 @@ msgstr "Configure how this predictor is calculated."
 msgid "Organisation units providing data"
 msgstr "Organisation units providing data"
 
-msgid "Sequential sample count (required)"
-msgstr "Sequential sample count (required)"
-
-msgid "Annual sample count (required)"
-msgstr "Annual sample count (required)"
-
 msgid "generator"
 msgstr "generator"
 
@@ -4547,17 +4781,11 @@ msgstr "Please enter a maximum of {{max}} characters"
 msgid "A variable with this name already exists in this program."
 msgstr "A variable with this name already exists in this program."
 
-msgid "Source type (required)"
-msgstr "Source type (required)"
-
 msgid "Set up the basic information for this program rule variable."
 msgstr "Set up the basic information for this program rule variable."
 
 msgid "Configure how this variable works."
 msgstr "Configure how this variable works."
-
-msgid "Program (required)"
-msgstr "Program (required)"
 
 msgid "Program cannot be changed after creation"
 msgstr "Program cannot be changed after creation"
@@ -4581,8 +4809,8 @@ msgstr "Set up condition expression"
 msgid "Expression can not be edited after saving"
 msgstr "Expression can not be edited after saving"
 
-msgid "Expression (required) *"
-msgstr "Expression (required) *"
+msgid "Expression *"
+msgstr "Expression *"
 
 msgid "Feedback widget"
 msgstr "Feedback widget"
@@ -4590,17 +4818,18 @@ msgstr "Feedback widget"
 msgid "Program indicator widget"
 msgstr "Program indicator widget"
 
-msgid "Display widget (required)"
-msgstr "Display widget (required)"
+msgid "Display widget"
+msgstr "Display widget"
 
 msgid "Message template can not be edited after saving"
 msgstr "Message template can not be edited after saving"
 
-msgid "Message template (required)"
-msgstr "Message template (required)"
-
-msgid "Can be 0 or negative. Leave empty if not needed."
-msgstr "Can be 0 or negative. Leave empty if not needed."
+msgid ""
+"Enter a number to set run order. Lower numbers run first. Leave empty to "
+"use the default order."
+msgstr ""
+"Enter a number to set run order. Lower numbers run first. Leave empty to "
+"use the default order."
 
 msgid "Program rule variable to assign to"
 msgstr "Program rule variable to assign to"
@@ -4610,9 +4839,6 @@ msgstr "Program stage to trigger rule"
 
 msgid "Select a specific program stage that the rule should only trigger on."
 msgstr "Select a specific program stage that the rule should only trigger on."
-
-msgid "Program stage section to hide (required)"
-msgstr "Program stage section to hide (required)"
 
 msgid "Program stage section to hide"
 msgstr "Program stage section to hide"
@@ -4647,8 +4873,8 @@ msgstr "Configure the program rule action."
 msgid "This program rule action will not be editable after saving."
 msgstr "This program rule action will not be editable after saving."
 
-msgid "Action type (required)"
-msgstr "Action type (required)"
+msgid "Action type"
+msgstr "Action type"
 
 msgid "Save action"
 msgstr "Save action"
@@ -4661,6 +4887,9 @@ msgstr "Action will be deleted when the program rule is saved."
 
 msgid "Undo delete"
 msgstr "Undo delete"
+
+msgid "Priority: {{priority}}"
+msgstr "Priority: {{priority}}"
 
 msgid "Program rule must be saved before actions can be added"
 msgstr "Program rule must be saved before actions can be added"
@@ -4877,9 +5106,6 @@ msgstr "Unknown action type"
 msgid "Program Rule"
 msgstr "Program Rule"
 
-msgid "Name (required)"
-msgstr "Name (required)"
-
 msgid "Program stages to trigger rule"
 msgstr "Program stages to trigger rule"
 
@@ -5083,17 +5309,17 @@ msgstr "Only integers are allowed"
 msgid "Program Settings"
 msgstr "Program Settings"
 
-msgid "Set up advanced options for this program."
-msgstr "Set up advanced options for this program."
+msgid "Set up how data is collected for events in this program."
+msgstr "Set up how data is collected for events in this program."
 
-msgid "Allow user assignment of events"
-msgstr "Allow user assignment of events"
+msgid "Allow events to be assigned to users"
+msgstr "Allow events to be assigned to users"
 
-msgid "Block entry form after completed"
-msgstr "Block entry form after completed"
+msgid "Block data entry after completion"
+msgstr "Block data entry after completion"
 
-msgid "Pre-generate event UID"
-msgstr "Pre-generate event UID"
+msgid "Generate offline event IDs"
+msgstr "Generate offline event IDs"
 
 msgid "Related program"
 msgstr "Related program"
@@ -5106,9 +5332,6 @@ msgstr "Lock events a number of days after completion"
 
 msgid "Close data entry a number of days after event category combination end date"
 msgstr "Close data entry a number of days after event category combination end date"
-
-msgid "Settings"
-msgstr "Settings"
 
 msgid "Validation strategy"
 msgstr "Validation strategy"
@@ -5198,23 +5421,8 @@ msgstr "Recipient program attribute"
 msgid "Recipient data element"
 msgstr "Recipient data element"
 
-msgid "Event repetition"
-msgstr "Event repetition"
-
-msgid "Define the frequency of events within this stage."
-msgstr "Define the frequency of events within this stage."
-
-msgid "Event scheduling"
-msgstr "Event scheduling"
-
-msgid "Configure how and when events in this stage are scheduled."
-msgstr "Configure how and when events in this stage are scheduled."
-
-msgid "Completion options"
-msgstr "Completion options"
-
-msgid "Decide what should happen after a user completes this event."
-msgstr "Decide what should happen after a user completes this event."
+msgid "Set up automatic event creation and scheduling in this program stage."
+msgstr "Set up automatic event creation and scheduling in this program stage."
 
 msgid "Configure data collection for events in this program stage."
 msgstr "Configure data collection for events in this program stage."
@@ -5267,23 +5475,23 @@ msgstr "Saving a stage does not save other changes to the program"
 msgid "Stage form saved"
 msgstr "Stage form saved"
 
-msgid "A stage with this name already exists. Please choose another name."
-msgstr "A stage with this name already exists. Please choose another name."
-
 msgid "Configure the basic information for this program stage."
 msgstr "Configure the basic information for this program stage."
 
-msgid "Configuration options"
-msgstr "Configuration options"
+msgid "Data entry options"
+msgstr "Data entry options"
 
-msgid "Set up more advanced options for this program stage."
-msgstr "Set up more advanced options for this program stage."
+msgid "Set up how data is collected for events in this program stage."
+msgstr "Set up how data is collected for events in this program stage."
 
-msgid "Custom terminology"
-msgstr "Custom terminology"
+msgid "Completion options"
+msgstr "Completion options"
 
-msgid "Customise the wording of labels for this stage."
-msgstr "Customise the wording of labels for this stage."
+msgid "Decide what should happen after a user completes this event."
+msgstr "Decide what should happen after a user completes this event."
+
+msgid "Override default labels with program stage-specific terms."
+msgstr "Override default labels with program stage-specific terms."
 
 msgid "Custom label for report date"
 msgstr "Custom label for report date"
@@ -5296,9 +5504,6 @@ msgstr "Custom label for program stage"
 
 msgid "Custom label for event"
 msgstr "Custom label for event"
-
-msgid "Program stage form"
-msgstr "Program stage form"
 
 msgid "Configure the form for data collection for events in this program stage."
 msgstr "Configure the form for data collection for events in this program stage."
@@ -5323,44 +5528,72 @@ msgstr ""
 msgid "Edit or rearrange the data elements"
 msgstr "Edit or rearrange the data elements"
 
-msgid "On event completion, show a prompt to create a new event"
-msgstr "On event completion, show a prompt to create a new event"
+msgid "Ask user to create a new event after completion"
+msgstr "Ask user to create a new event after completion"
 
-msgid "Auto-generate an event in this stage"
-msgstr "Auto-generate an event in this stage"
+msgid "Create an event in this stage on enrollment"
+msgstr "Create an event in this stage on enrollment"
 
-msgid "Generate events based on enrollment date"
-msgstr "Generate events based on enrollment date"
+msgid "Reference date for scheduling"
+msgstr "Reference date for scheduling"
 
-msgid "Show scheduled date"
-msgstr "Show scheduled date"
+msgid "Hide scheduled date"
+msgstr "Hide scheduled date"
 
-msgid "Scheduled days from start (required)"
-msgstr "Scheduled days from start (required)"
+msgid ""
+"Android Capture will disable all scheduling. Web Capture will allow manual "
+"scheduling, but scheduled dates will not be editable."
+msgstr ""
+"Android Capture will disable all scheduling. Web Capture will allow manual "
+"scheduling, but scheduled dates will not be editable."
 
-msgid "Days to add to the enrollment or incident date. 0 means same day. "
-msgstr "Days to add to the enrollment or incident date. 0 means same day. "
+msgid "Scheduled days from reference date"
+msgstr "Scheduled days from reference date"
+
+msgid ""
+"Days to add to the enrollment or incident date when scheduling events. 0 "
+"means same day. "
+msgstr ""
+"Days to add to the enrollment or incident date when scheduling events. 0 "
+"means same day. "
 
 msgid "Default next scheduled date"
 msgstr "Default next scheduled date"
 
+msgid ""
+"If set, this date sets the next scheduled date. Standard interval days is "
+"used if the date is empty."
+msgstr ""
+"If set, this date sets the next scheduled date. Standard interval days is "
+"used if the date is empty."
+
 msgid "Open data entry form after enrollment"
 msgstr "Open data entry form after enrollment"
 
-msgid "On event completion, ask user to complete enrollment"
-msgstr "On event completion, ask user to complete enrollment"
+msgid ""
+"If set, only one event per period is allowed. Report date will be a period "
+"instead of a date. Not supported by web Capture."
+msgstr ""
+"If set, only one event per period is allowed. Report date will be a period "
+"instead of a date. Not supported by web Capture."
 
-msgid "Allow multiple events in this stage (repeatable stage)"
-msgstr "Allow multiple events in this stage (repeatable stage)"
+msgid "Ask user to complete enrollment after completion"
+msgstr "Ask user to complete enrollment after completion"
 
-msgid "Report date to use"
-msgstr "Report date to use"
+msgid "Allow multiple events in this stage"
+msgstr "Allow multiple events in this stage"
+
+msgid "None (report date will be empty)"
+msgstr "None (report date will be empty)"
+
+msgid "Date to use for created event report date"
+msgstr "Date to use for created event report date"
 
 msgid "Standard interval days"
 msgstr "Standard interval days"
 
-msgid "Enter the number of days between repeated events."
-msgstr "Enter the number of days between repeated events."
+msgid "The number of days between repeated events."
+msgstr "The number of days between repeated events."
 
 msgid "Stage section"
 msgstr "Stage section"
@@ -5392,26 +5625,11 @@ msgstr "Desktop display"
 msgid "Mobile display"
 msgstr "Mobile display"
 
-msgid "Stage: Setup"
-msgstr "Stage: Setup"
+msgid "Creation and scheduling"
+msgstr "Creation and scheduling"
 
-msgid "Stage: Configuration"
-msgstr "Stage: Configuration"
-
-msgid "Stage: Terminology"
-msgstr "Stage: Terminology"
-
-msgid "Stage: Creation and Scheduling"
-msgstr "Stage: Creation and Scheduling"
-
-msgid "Scheduled days from start"
-msgstr "Scheduled days from start"
-
-msgid "Stage: Data"
-msgstr "Stage: Data"
-
-msgid "Stage: Form"
-msgstr "Stage: Form"
+msgid "Program stage form"
+msgstr "Program stage form"
 
 msgid "Section tracked entity attributes"
 msgstr "Section tracked entity attributes"
@@ -5502,6 +5720,16 @@ msgid ""
 msgstr ""
 "Do not create overdue events when automatically creating program stage "
 "events"
+
+msgid "Mandatory tracked entity attributes are not included in this form."
+msgstr "Mandatory tracked entity attributes are not included in this form."
+
+msgid ""
+"The following attributes are marked as required but not assigned to any "
+"section:"
+msgstr ""
+"The following attributes are marked as required but not assigned to any "
+"section:"
 
 msgid "Custom label for \"Incident date\""
 msgstr "Custom label for \"Incident date\""
@@ -5672,16 +5900,6 @@ msgid ""
 msgstr ""
 "Searches using these operators return no results. Use this to prevent "
 "inefficient searches."
-
-msgid "Confidential"
-msgstr "Confidential"
-
-msgid ""
-"Prevent searching or viewing in analytics. Available only when system "
-"encryption is enabled."
-msgstr ""
-"Prevent searching or viewing in analytics. Available only when system "
-"encryption is enabled."
 
 msgid "Inherit values from tracked entities linked by a relationship"
 msgstr "Inherit values from tracked entities linked by a relationship"

--- a/src/app/routes/Router.tsx
+++ b/src/app/routes/Router.tsx
@@ -150,6 +150,7 @@ const EditBreadcrumbItem = ({
         ? i18n.t('Edit: {{objectName}}', {
               objectName: data.displayName,
               interpolation: { escapeValue: false },
+              nsSeparator: '~:~',
           })
         : i18n.t('Edit')
 

--- a/src/components/ColorAndIconPicker/ColorPicker.tsx
+++ b/src/components/ColorAndIconPicker/ColorPicker.tsx
@@ -35,7 +35,7 @@ export function ColorPicker({
                 aria-label={
                     color
                         ? `${i18n.t('Color')}: ${color}`
-                        : i18n.t('Color: none selected')
+                        : i18n.t('Color: none selected', { nsSeparator: '~:~' })
                 }
             >
                 <span className={classes.label}>{i18n.t('Color')}</span>

--- a/src/components/ColorAndIconPicker/IconPicker.tsx
+++ b/src/components/ColorAndIconPicker/IconPicker.tsx
@@ -28,7 +28,7 @@ export function IconPicker({
                 aria-label={
                     icon
                         ? `${i18n.t('Icon')}: ${icon}`
-                        : i18n.t('Icon: none selected')
+                        : i18n.t('Icon: none selected', { nsSeparator: '~:~' })
                 }
             >
                 <span className={classes.label}>{i18n.t('Icon')}</span>

--- a/src/components/form/TranslatedFieldsNoticeBox.tsx
+++ b/src/components/form/TranslatedFieldsNoticeBox.tsx
@@ -20,6 +20,7 @@ export function TranslatedFieldsNoticeBox() {
                     initialValues.displayName !== initialValues.name
                         ? i18n.t('Name: {{- displayName}} (Translated)', {
                               displayName: initialValues.displayName,
+                              nsSeparator: '~:~',
                           })
                         : undefined
                 }

--- a/src/components/formCreators/TabbedFormTypePicker.tsx
+++ b/src/components/formCreators/TabbedFormTypePicker.tsx
@@ -48,10 +48,16 @@ export const TabbedFormTypePicker = React.memo(function FormFormContents({
                     title={i18n.t('Form type based on current setup')}
                     className={classes.formTypeInfo}
                 >
-                    <div>{i18n.t('Web: {{webFormType}}', { webFormType })}</div>
+                    <div>
+                        {i18n.t('Web: {{webFormType}}', {
+                            webFormType,
+                            nsSeparator: '~:~',
+                        })}
+                    </div>
                     <div>
                         {i18n.t('Android: {{androidFormType}}', {
                             androidFormType,
+                            nsSeparator: '~:~',
                         })}
                     </div>
                 </NoticeBox>

--- a/src/pages/attributes/form/attributesFormFields.tsx
+++ b/src/pages/attributes/form/attributesFormFields.tsx
@@ -82,7 +82,8 @@ export const AttributeFormFields = ({
                         component={CheckboxFieldFF}
                         name="mandatory"
                         label={i18n.t(
-                            'Mandatory: all objects must have a value for this attribute'
+                            'Mandatory: all objects must have a value for this attribute',
+                            { nsSeparator: '~:~' }
                         )}
                         type="checkbox"
                         dataTest="formfields-mandatory"

--- a/src/pages/dataElementGroupSets/fields/CompulsoryField.tsx
+++ b/src/pages/dataElementGroupSets/fields/CompulsoryField.tsx
@@ -10,7 +10,8 @@ export function CompulsoryField() {
             dataTest="formfields-compulsory"
             name="compulsory"
             label={i18n.t(
-                'Compulsory: all data elements must belong to at least one group in this group set.'
+                'Compulsory: all data elements must belong to at least one group in this group set.',
+                { nsSeparator: '~:~' }
             )}
             type="checkbox"
             validateFields={[]}

--- a/src/pages/indicatorGroupSets/form/IndicatorGroupSetFormFields.tsx
+++ b/src/pages/indicatorGroupSets/form/IndicatorGroupSetFormFields.tsx
@@ -33,7 +33,8 @@ function IndicatorGroupSetFormFields() {
                         component={CheckboxFieldFF}
                         name="compulsory"
                         label={i18n.t(
-                            'Compulsory: all indicators must belong to at least one group in this group set.'
+                            'Compulsory: all indicators must belong to at least one group in this group set.',
+                            { nsSeparator: '~:~' }
                         )}
                         type="checkbox"
                     />

--- a/src/pages/organisationUnitGroupSets/form/OrganisationalUnitGroupSetFormFields.tsx
+++ b/src/pages/organisationUnitGroupSets/form/OrganisationalUnitGroupSetFormFields.tsx
@@ -37,7 +37,8 @@ export const OrganisationalUnitGroupSetFormFields = () => {
                         component={CheckboxFieldFF}
                         name="compulsory"
                         label={i18n.t(
-                            'Compulsory: all organisation units must belong to at least one group in this group set.'
+                            'Compulsory: all organisation units must belong to at least one group in this group set.',
+                            { nsSeparator: '~:~' }
                         )}
                         type="checkbox"
                         validateFields={[]}

--- a/src/pages/programRuleVariables/fields/ProgramRuleVariableNameField.tsx
+++ b/src/pages/programRuleVariables/fields/ProgramRuleVariableNameField.tsx
@@ -47,7 +47,8 @@ const forbiddenWordsValidator: FormFieldValidator<string> = (value) => {
     }
     if (containsForbiddenWord(value)) {
         return i18n.t(
-            'Program rule variable name contains forbidden words: and, or, not.'
+            'Program rule variable name contains forbidden words: and, or, not.',
+            { nsSeparator: '~:~' }
         )
     }
     return undefined
@@ -160,7 +161,8 @@ export function ProgramRuleVariableNameField() {
                     inputWidth="400px"
                     label={i18n.t('Name')}
                     helpText={i18n.t(
-                        'Variable name cannot contain the words: and, or, not.'
+                        'Variable name cannot contain the words: and, or, not.',
+                        { nsSeparator: '~:~' }
                     )}
                 />
             )}

--- a/src/pages/programRules/form/actions/constants.ts
+++ b/src/pages/programRules/form/actions/constants.ts
@@ -90,7 +90,8 @@ export const VALIDATION_MESSAGES = {
     ),
     OPTIONGROUP_GROUP: i18n.t('Option group is required'),
     SETMANDATORYFIELD: i18n.t(
-        'Select at least one: data element or tracked entity attribute'
+        'Select at least one: data element or tracked entity attribute',
+        { nsSeparator: '~:~' }
     ),
     STATIC_TEXT_REQUIRED: i18n.t('Static text is required'),
 } as const

--- a/src/pages/programs/form/RoleAccess/RoleAccess.tsx
+++ b/src/pages/programs/form/RoleAccess/RoleAccess.tsx
@@ -170,6 +170,7 @@ export const RoleAccess = ({
                 <RoleAccessBox
                     title={i18n.t('Program: {{name}}', {
                         name: values.name || i18n.t('Untitled'),
+                        nsSeparator: '~:~',
                     })}
                     type="program"
                     sharing={values.sharing}
@@ -187,6 +188,7 @@ export const RoleAccess = ({
                             key={stage.id}
                             title={i18n.t('Stage: {{name}}', {
                                 name: stage.displayName,
+                                nsSeparator: '~:~',
                             })}
                             type="stage"
                             sharing={stage.sharing}

--- a/src/pages/programs/form/RoleAccess/RoleAccessBox.tsx
+++ b/src/pages/programs/form/RoleAccess/RoleAccessBox.tsx
@@ -172,6 +172,7 @@ export const RoleAccessBox = ({
                                     prefix,
                                     name: entity.displayName,
                                     interpolation: { escapeValue: false },
+                                    nsSeparator: '~:~',
                                 })}
                             </div>
                             <div

--- a/src/pages/programs/form/common/ProgramNotificationsFormContents.tsx
+++ b/src/pages/programs/form/common/ProgramNotificationsFormContents.tsx
@@ -129,7 +129,8 @@ const ProgramNotificationListNewOrEdit = ({
                             item={{
                                 ...notification,
                                 description: i18n.t(
-                                    'Notification type: Program'
+                                    'Notification type: Program',
+                                    { nsSeparator: '~:~' }
                                 ),
                             }}
                             schemaName={SchemaName.programNotificationTemplate}

--- a/src/pages/trackedEntityTypes/Edit.tsx
+++ b/src/pages/trackedEntityTypes/Edit.tsx
@@ -112,6 +112,7 @@ export const Component = () => {
                         {
                             programNames,
                             interpolation: { escapeValue: false },
+                            nsSeparator: '~:~',
                         }
                     ),
                     warning: true,


### PR DESCRIPTION
This PR adds in non-default nsSeparator (`nsSeparator: '~:~'`) for translation strings which contain a `:` (where not already present). This prevents problems with translation string scanning by i18next-scanner as the colon is interpreted as the distinction between key/namespace (which we do not use).

This will stop us from getting these warnings on start up:
<img width="535" height="183" alt="image" src="https://github.com/user-attachments/assets/ed3cfff1-6ffe-4461-9602-2fef68778da0" />
