### PR TITLE
feat: update help text in data set sections [DHIS2-21437]

### DIFF
--- a/src/pages/dataSets/form/dataEntryForm/sectionForm/DataSetSectionFormContents.tsx
+++ b/src/pages/dataSets/form/dataEntryForm/sectionForm/DataSetSectionFormContents.tsx
@@ -351,7 +351,7 @@ export const DataSetSectionFormContents = ({
                                     'Content to display before a section'
                                 )}
                                 helpText={i18n.t(
-                                    'HTML links and basic styling can be included'
+                                    'Markdown formatting is supported'
                                 )}
                                 format={(value) =>
                                     typeof value === 'string'
@@ -370,7 +370,7 @@ export const DataSetSectionFormContents = ({
                                 )}
                                 validateFields={[]}
                                 helpText={i18n.t(
-                                    'HTML links and basic styling can be included'
+                                    'Markdown formatting is supported'
                                 )}
                                 format={(value) =>
                                     typeof value === 'string'


### PR DESCRIPTION
Update help text in data set sections: Content to display before/after a section

[DHIS2-21437](https://dhis2.atlassian.net/browse/DHIS2-21437)

<img width="473" height="596" alt="image" src="https://github.com/user-attachments/assets/e6b433cd-9d69-4df7-bcec-3de4788d8f2e" />


[DHIS2-21437]: https://dhis2.atlassian.net/browse/DHIS2-21437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ