### PR TITLE
feat: sql view form [DHIS2-21243]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-05-07T08:04:05.825Z\n"
-"PO-Revision-Date: 2026-05-07T08:04:05.825Z\n"
+"POT-Creation-Date: 2026-05-12T12:57:30.057Z\n"
+"PO-Revision-Date: 2026-05-12T12:57:30.057Z\n"
 
 msgid "schemas"
 msgstr "schemas"
@@ -44,6 +44,9 @@ msgstr "Duplication not available yet."
 
 msgid "{{-sectionName}} cannot be duplicated."
 msgstr "{{-sectionName}} cannot be duplicated."
+
+msgid "Edit: {{objectName}}"
+msgstr "Edit: {{objectName}}"
 
 msgid "Edit"
 msgstr "Edit"
@@ -90,11 +93,17 @@ msgstr "Color and icon"
 msgid "Color"
 msgstr "Color"
 
+msgid "Color: none selected"
+msgstr "Color: none selected"
+
 msgid "Remove color"
 msgstr "Remove color"
 
 msgid "Icon"
 msgstr "Icon"
+
+msgid "Icon: none selected"
+msgstr "Icon: none selected"
 
 msgid "Choose an icon"
 msgstr "Choose an icon"
@@ -581,6 +590,9 @@ msgstr "Show error details"
 msgid "Save and close"
 msgstr "Save and close"
 
+msgid "Name: {{- displayName}} (Translated)"
+msgstr "Name: {{- displayName}} (Translated)"
+
 msgid ""
 "Translatable fields appear in the default language in this form, not in "
 "your selected database language."
@@ -813,6 +825,12 @@ msgstr "Show data items in a simple list."
 
 msgid "Form type based on current setup"
 msgstr "Form type based on current setup"
+
+msgid "Web: {{webFormType}}"
+msgstr "Web: {{webFormType}}"
+
+msgid "Android: {{androidFormType}}"
+msgstr "Android: {{androidFormType}}"
 
 msgid ""
 "Organise data items into sections for easier entry. Section forms are used "
@@ -2258,6 +2276,15 @@ msgstr "Initiating entity type"
 msgid "Receiving entity type"
 msgstr "Receiving entity type"
 
+msgid "SQL type"
+msgstr "SQL type"
+
+msgid "Cache strategy"
+msgstr "Cache strategy"
+
+msgid "SQL query"
+msgstr "SQL query"
+
 msgid "Unique"
 msgstr "Unique"
 
@@ -2492,6 +2519,9 @@ msgstr "Set up the basic information for this attribute."
 
 msgid "Configure how this attribute wil be collected, analyzed, and stored."
 msgstr "Configure how this attribute wil be collected, analyzed, and stored."
+
+msgid "Mandatory: all objects must have a value for this attribute"
+msgstr "Mandatory: all objects must have a value for this attribute"
 
 msgid "Unique values only"
 msgstr "Unique values only"
@@ -2728,6 +2758,13 @@ msgid ""
 msgstr ""
 "An approval level for this organisation unit level and category option "
 "group set combination already exists."
+
+msgid ""
+"Compulsory: all data elements must belong to at least one group in this "
+"group set."
+msgstr ""
+"Compulsory: all data elements must belong to at least one group in this "
+"group set."
 
 msgid "Available data element groups"
 msgstr "Available data element groups"
@@ -3430,6 +3467,13 @@ msgstr "Advanced"
 msgid "Set up the basic information for this indicator group set."
 msgstr "Set up the basic information for this indicator group set."
 
+msgid ""
+"Compulsory: all indicators must belong to at least one group in this group "
+"set."
+msgstr ""
+"Compulsory: all indicators must belong to at least one group in this group "
+"set."
+
 msgid "Choose the indicators to include in this indicator group."
 msgstr "Choose the indicators to include in this indicator group."
 
@@ -3853,6 +3897,13 @@ msgstr "There was an error deleting options: {{optionIds}}"
 
 msgid "Set up the basic information for this organisation unit group set."
 msgstr "Set up the basic information for this organisation unit group set."
+
+msgid ""
+"Compulsory: all organisation units must belong to at least one group in "
+"this group set."
+msgstr ""
+"Compulsory: all organisation units must belong to at least one group in "
+"this group set."
 
 msgid "Inherit parent organisation unit groups"
 msgstr "Inherit parent organisation unit groups"
@@ -4775,11 +4826,17 @@ msgstr "Show program indicators in data entry forms"
 msgid "Name can only contain letters, numbers, space, dash, dot and underscore"
 msgstr "Name can only contain letters, numbers, space, dash, dot and underscore"
 
+msgid "Program rule variable name contains forbidden words: and, or, not."
+msgstr "Program rule variable name contains forbidden words: and, or, not."
+
 msgid "Please enter a maximum of {{max}} characters"
 msgstr "Please enter a maximum of {{max}} characters"
 
 msgid "A variable with this name already exists in this program."
 msgstr "A variable with this name already exists in this program."
+
+msgid "Variable name cannot contain the words: and, or, not."
+msgstr "Variable name cannot contain the words: and, or, not."
 
 msgid "Set up the basic information for this program rule variable."
 msgstr "Set up the basic information for this program rule variable."
@@ -5046,6 +5103,9 @@ msgstr "Message template is required"
 msgid "Option group is required"
 msgstr "Option group is required"
 
+msgid "Select at least one: data element or tracked entity attribute"
+msgstr "Select at least one: data element or tracked entity attribute"
+
 msgid "Static text is required"
 msgstr "Static text is required"
 
@@ -5146,8 +5206,14 @@ msgstr "Failed to apply access to all stages"
 msgid "Failed to apply program access rules"
 msgstr "Failed to apply program access rules"
 
+msgid "Program: {{name}}"
+msgstr "Program: {{name}}"
+
 msgid "Untitled"
 msgstr "Untitled"
+
+msgid "Stage: {{name}}"
+msgstr "Stage: {{name}}"
 
 msgid "No data access"
 msgstr "No data access"
@@ -5190,6 +5256,9 @@ msgstr "External"
 
 msgid "Group"
 msgstr "Group"
+
+msgid "{{prefix}}: {{name}}"
+msgstr "{{prefix}}: {{name}}"
 
 msgid "Set up how users can access program data outside their capture scope."
 msgstr "Set up how users can access program data outside their capture scope."
@@ -5248,6 +5317,9 @@ msgstr "Notification {{- notificationName}} will be removed on save"
 
 msgid "Restore notification"
 msgstr "Restore notification"
+
+msgid "Notification type: Program"
+msgstr "Notification type: Program"
 
 msgid "Notification type: Stage | Stage: {{stageDisplayName}}"
 msgstr "Notification type: Stage | Stage: {{stageDisplayName}}"
@@ -5879,6 +5951,74 @@ msgstr ""
 "Relationship name seen from receiving entity is required when bidirectional "
 "is checked"
 
+msgid "SQL view results"
+msgstr "SQL view results"
+
+msgid "Materialized view refreshed."
+msgstr "Materialized view refreshed."
+
+msgid "SQL view created or updated."
+msgstr "SQL view created or updated."
+
+msgid "An unknown error occurred."
+msgstr "An unknown error occurred."
+
+msgid "Could not run SQL view: {{error}}"
+msgstr "Could not run SQL view: {{error}}"
+
+msgid "View results"
+msgstr "View results"
+
+msgid "Run query"
+msgstr "Run query"
+
+msgid "Create or update view"
+msgstr "Create or update view"
+
+msgid "Current user id"
+msgstr "Current user id"
+
+msgid "Current username"
+msgstr "Current username"
+
+msgid "SQL query *"
+msgstr "SQL query *"
+
+msgid ""
+"Only SELECT statements allowed. Sensitive tables, including user "
+"information, cannot be queried."
+msgstr ""
+"Only SELECT statements allowed. Sensitive tables, including user "
+"information, cannot be queried."
+
+msgid "Set up how this SQL view is identified and described."
+msgstr "Set up how this SQL view is identified and described."
+
+msgid "Controls how long results are cached on the server before re-execution"
+msgstr "Controls how long results are cached on the server before re-execution"
+
+msgid "SQL definition"
+msgstr "SQL definition"
+
+msgid "Choose the type of SQL view and write the query."
+msgstr "Choose the type of SQL view and write the query."
+
+msgid "SQL type cannot be changed after creation."
+msgstr "SQL type cannot be changed after creation."
+
+msgid "View: SQL query is stored in the database; results are generated each time."
+msgstr "View: SQL query is stored in the database; results are generated each time."
+
+msgid "Materialized view: SQL query is stored, and results are cached."
+msgstr "Materialized view: SQL query is stored, and results are cached."
+
+msgid ""
+"Query only: Neither query nor results stored in the database. Supports "
+"inline $(variable) references."
+msgstr ""
+"Query only: Neither query nor results stored in the database. Supports "
+"inline $(variable) references."
+
 msgid "SW | Starts with"
 msgstr "SW | Starts with"
 
@@ -6016,6 +6156,13 @@ msgstr "Skip synchronization"
 
 msgid "Minimum characters to search"
 msgstr "Minimum characters to search"
+
+msgid ""
+"After changing the tracked entity type attributes, you may need to update "
+"the following program(s): {{programNames}}."
+msgstr ""
+"After changing the tracked entity type attributes, you may need to update "
+"the following program(s): {{programNames}}."
 
 msgid "Choose which attributes to show, require, and make searchable."
 msgstr "Choose which attributes to show, require, and make searchable."

--- a/src/lib/constants/sections.ts
+++ b/src/lib/constants/sections.ts
@@ -344,6 +344,7 @@ export const SCHEMA_SECTIONS = {
         title: i18n.t('SQL view'),
         titlePlural: i18n.t('SQL views'),
         parentSectionKey: 'other',
+        duplicable: true,
     },
     legendSet: {
         name: SchemaName.legendSet,

--- a/src/lib/constants/translatedModelConstants.ts
+++ b/src/lib/constants/translatedModelConstants.ts
@@ -278,14 +278,14 @@ const MATERIALIZED_VIEW = {
 
 const CACHE_STRATEGY = {
     NO_CACHE: 'No cache',
-    CACHE_1_MINUTE: 'Cache 1 minute',
-    CACHE_5_MINUTES: 'Cache 5 minutes',
-    CACHE_10_MINUTES: 'Cache 10 minutes',
-    CACHE_15_MINUTES: 'Cache 15 minutes',
-    CACHE_30_MINUTES: 'Cache 30 minutes',
-    CACHE_1_HOUR: 'Cache 1 hour',
-    CACHE_6AM_TOMORROW: 'Cache 6am tomorrow',
-    CACHE_TWO_WEEKS: 'Cache 2 weeks',
+    CACHE_1_MINUTE: 'Cache for 1 minute',
+    CACHE_5_MINUTES: 'Cache for 5 minutes',
+    CACHE_10_MINUTES: 'Cache for 10 minutes',
+    CACHE_15_MINUTES: 'Cache for 15 minutes',
+    CACHE_30_MINUTES: 'Cache for 30 minutes',
+    CACHE_1_HOUR: 'Cache for one hour',
+    CACHE_6AM_TOMORROW: 'Cache until 6am tomorrow',
+    CACHE_TWO_WEEKS: 'Cache for two weeks',
     RESPECT_SYSTEM_SETTING: 'Respect system setting',
 }
 

--- a/src/pages/sqlViews/Duplicate.tsx
+++ b/src/pages/sqlViews/Duplicate.tsx
@@ -1,0 +1,71 @@
+import { useQuery } from '@tanstack/react-query'
+import { omit } from 'lodash'
+import React, { useMemo } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { FormBase } from '../../components'
+import { DefaultDuplicateFormContents } from '../../components/form/DefaultFormContents'
+import {
+    ATTRIBUTE_VALUES_FIELD_FILTERS,
+    DEFAULT_FIELD_FILTERS,
+    SECTIONS_MAP,
+    useOnSubmitNew,
+} from '../../lib'
+import { useBoundResourceQueryFn } from '../../lib/query/useBoundQueryFn'
+import { SqlView, PickWithFieldFilters } from '../../types/generated'
+import { SqlViewFormFields, validate } from './form'
+
+const fieldFilters = [
+    ...DEFAULT_FIELD_FILTERS,
+    ...ATTRIBUTE_VALUES_FIELD_FILTERS,
+    'name',
+    'description',
+    'type',
+    'cacheStrategy',
+    'sqlQuery',
+] as const
+
+export type SqlViewFormValues = PickWithFieldFilters<
+    SqlView,
+    typeof fieldFilters
+>
+
+const section = SECTIONS_MAP.sqlView
+
+export const Component = () => {
+    const queryFn = useBoundResourceQueryFn()
+    const [searchParams] = useSearchParams()
+    const duplicatedModelId = searchParams.get('duplicatedId') as string
+
+    const query = {
+        resource: 'sqlViews',
+        id: duplicatedModelId,
+        params: {
+            fields: fieldFilters.concat(),
+        },
+    }
+    const sqlViewQuery = useQuery({
+        queryKey: [query],
+        queryFn: queryFn<SqlViewFormValues>,
+    })
+
+    const onSubmit = useOnSubmitNew<Omit<SqlViewFormValues, 'id'>>({
+        section,
+    })
+
+    const initialValues = useMemo(() => {
+        return sqlViewQuery.data ? omit(sqlViewQuery.data, 'id') : undefined
+    }, [sqlViewQuery.data])
+
+    return (
+        <FormBase
+            onSubmit={onSubmit}
+            initialValues={initialValues}
+            validate={validate}
+            fetchError={!!sqlViewQuery.error}
+        >
+            <DefaultDuplicateFormContents section={section}>
+                <SqlViewFormFields />
+            </DefaultDuplicateFormContents>
+        </FormBase>
+    )
+}

--- a/src/pages/sqlViews/Edit.tsx
+++ b/src/pages/sqlViews/Edit.tsx
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query'
+import React from 'react'
+import { useParams } from 'react-router-dom'
+import { DefaultEditFormContents, FormBase } from '../../components'
+import {
+    useOnSubmitEdit,
+    useBoundResourceQueryFn,
+    SECTIONS_MAP,
+    DEFAULT_FIELD_FILTERS,
+    ATTRIBUTE_VALUES_FIELD_FILTERS,
+} from '../../lib'
+import { SqlView, PickWithFieldFilters } from '../../types/generated'
+import { SqlViewFormFields, validate } from './form'
+
+const fieldFilters = [
+    ...DEFAULT_FIELD_FILTERS,
+    ...ATTRIBUTE_VALUES_FIELD_FILTERS,
+    'name',
+    'description',
+    'type',
+    'cacheStrategy',
+    'sqlQuery',
+] as const
+
+export type SqlViewFormValues = PickWithFieldFilters<
+    SqlView,
+    typeof fieldFilters
+> & { id: string }
+
+export const Component = () => {
+    const section = SECTIONS_MAP.sqlView
+    const queryFn = useBoundResourceQueryFn()
+    const modelId = useParams().id as string
+
+    const query = {
+        resource: 'sqlViews',
+        id: modelId,
+        params: {
+            fields: fieldFilters.concat(),
+        },
+    }
+    const sqlView = useQuery({
+        queryKey: [query],
+        queryFn: queryFn<SqlViewFormValues>,
+    })
+
+    return (
+        <FormBase
+            onSubmit={useOnSubmitEdit({ modelId, section })}
+            initialValues={sqlView.data}
+            validate={validate}
+        >
+            <DefaultEditFormContents section={section}>
+                <SqlViewFormFields />
+            </DefaultEditFormContents>
+        </FormBase>
+    )
+}

--- a/src/pages/sqlViews/Form.spec.tsx
+++ b/src/pages/sqlViews/Form.spec.tsx
@@ -1,0 +1,327 @@
+import { faker } from '@faker-js/faker'
+import { render, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import schemaMock from '../../__mocks__/schema/sqlView.json'
+import { FOOTER_ID } from '../../app/layout/Layout'
+import { getConstantTranslation, SECTIONS_MAP } from '../../lib'
+import {
+    randomLongString,
+    testCustomAttribute,
+    testSqlViews,
+} from '../../testUtils/builders'
+import { generateRenderer } from '../../testUtils/generateRenderer'
+import TestComponentWithRouter from '../../testUtils/TestComponentWithRouter'
+import { uiActions } from '../../testUtils/uiActions'
+import { uiAssertions } from '../../testUtils/uiAssertions'
+import { SqlView } from '../../types/generated'
+import { Component as Edit } from './Edit'
+import { Component as New } from './New'
+import resetAllMocks = jest.resetAllMocks
+
+const section = SECTIONS_MAP.sqlView
+const mockSchema = schemaMock
+
+jest.mock('use-debounce', () => ({
+    useDebouncedCallback: (fn: any) => fn,
+}))
+
+describe('SQL Views form tests', () => {
+    const createMock = jest.fn()
+    const updateMock = jest.fn()
+
+    beforeEach(() => {
+        resetAllMocks()
+        const portalRoot = document.createElement('div')
+        portalRoot.setAttribute('id', FOOTER_ID)
+        document.body.appendChild(portalRoot)
+    })
+
+    afterEach(() => {
+        const portalRoot = document.getElementById(FOOTER_ID)
+        if (portalRoot) {
+            portalRoot.remove()
+        }
+    })
+
+    describe('New', () => {
+        const renderForm = generateRenderer(
+            { section, mockSchema },
+            (routeOptions) => {
+                const attributes = [testCustomAttribute({ mandatory: false })]
+                const screen = render(
+                    <TestComponentWithRouter
+                        path={`/${section.namePlural}`}
+                        customData={{
+                            attributes: () => ({ attributes }),
+                            sqlViews: (type: any, params: any) => {
+                                if (type === 'create') {
+                                    createMock(params)
+                                    return { statusCode: 204 }
+                                }
+                                if (type === 'read') {
+                                    return { pager: { total: 0 }, sqlViews: [] }
+                                }
+                            },
+                        }}
+                        routeOptions={routeOptions}
+                    >
+                        <New />
+                    </TestComponentWithRouter>
+                )
+                return { screen, attributes }
+            }
+        )
+
+        it('should contain all needed fields', async () => {
+            const { screen, attributes } = await renderForm()
+
+            uiAssertions.expectNameFieldExist('', screen)
+            uiAssertions.expectTextAreaFieldToExist('description', '', screen)
+
+            const cacheStrategyField = screen.getByTestId(
+                'formfields-cacheStrategy'
+            )
+            const selectInput = within(cacheStrategyField).getByTestId(
+                'dhis2-uicore-select-input'
+            )
+            expect(selectInput).toHaveTextContent(
+                getConstantTranslation(
+                    SqlView.cacheStrategy.RESPECT_SYSTEM_SETTING
+                )
+            )
+
+            uiAssertions.expectRadioFieldToExist(
+                'type',
+                [
+                    { label: 'View: SQL', checked: true },
+                    { label: 'Materialized view:', checked: false },
+                    { label: 'Query only:', checked: false },
+                ],
+                screen
+            )
+
+            uiAssertions.expectTextAreaFieldToExist('sqlQuery', '', screen)
+
+            attributes.forEach((attribute: { id: string }) => {
+                expect(
+                    screen.getByTestId(`attribute-${attribute.id}`)
+                ).toBeVisible()
+            })
+        })
+
+        it('should not submit when required values are missing', async () => {
+            const { screen } = await renderForm()
+            await uiActions.submitForm(screen)
+            expect(createMock).not.toHaveBeenCalled()
+            uiAssertions.expectFieldToHaveError(
+                'formfields-name',
+                'Required',
+                screen
+            )
+        })
+
+        it('should show query variable buttons only when type is QUERY', async () => {
+            const { screen } = await renderForm()
+
+            // View type selected initially — buttons not rendered
+            uiAssertions.expectRadioFieldToExist(
+                'type',
+                [
+                    { label: 'View: SQL', checked: true },
+                    { label: 'Materialized view:', checked: false },
+                    { label: 'Query only:', checked: false },
+                ],
+                screen
+            )
+            expect(
+                screen.queryByTestId('queryVariable_button__current_user_id')
+            ).not.toBeInTheDocument()
+            expect(
+                screen.queryByTestId('queryVariable_button__current_username')
+            ).not.toBeInTheDocument()
+
+            // Select QUERY (third radio)
+            const typeField = screen.getByTestId('formfields-type')
+            const typeRadios = within(typeField).getAllByRole('radio')
+            await userEvent.click(typeRadios[2])
+
+            expect(
+                screen.getByTestId('queryVariable_button__current_user_id')
+            ).toBeVisible()
+            expect(
+                screen.getByTestId('queryVariable_button__current_username')
+            ).toBeVisible()
+
+            // Switch to MATERIALIZED_VIEW (second radio) — buttons should disappear
+            await userEvent.click(typeRadios[1])
+
+            expect(
+                screen.queryByTestId('queryVariable_button__current_user_id')
+            ).not.toBeInTheDocument()
+            expect(
+                screen.queryByTestId('queryVariable_button__current_username')
+            ).not.toBeInTheDocument()
+        })
+
+        it('should show an error if name field is too long', async () => {
+            const { screen } = await renderForm()
+            const longText = randomLongString(231)
+            await uiActions.enterName(longText, screen)
+            await uiAssertions.expectNameToErrorWhenExceedsLength(screen)
+            await uiActions.submitForm(screen)
+            expect(createMock).not.toHaveBeenCalled()
+        })
+
+        it('should have a cancel button with a link back to the list view', async () => {
+            const { screen } = await renderForm()
+            const cancelButton = screen.getByTestId('form-cancel-link')
+            expect(cancelButton).toBeVisible()
+            expect(cancelButton).toHaveAttribute(
+                'href',
+                `/${section.namePlural}`
+            )
+        })
+
+        it('should submit the data', async () => {
+            const { screen } = await renderForm()
+            const aName = faker.animal.bird()
+            const aDescription = faker.company.buzzPhrase()
+            const aSqlQuery = `SELECT * FROM ${faker.database.column()}`
+
+            await uiActions.enterName(aName, screen)
+            await uiActions.enterInputFieldValue(
+                'description',
+                aDescription,
+                screen
+            )
+
+            const cacheStrategyField = screen.getByTestId(
+                'formfields-cacheStrategy'
+            )
+            await uiActions.pickOptionFromSelect(cacheStrategyField, 0, screen)
+
+            const typeField = screen.getByTestId('formfields-type')
+            const typeRadios = within(typeField).getAllByRole('radio')
+            await userEvent.click(typeRadios[0])
+
+            await uiActions.enterInputFieldValue('sqlQuery', aSqlQuery, screen)
+
+            await uiActions.submitForm(screen)
+
+            expect(createMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({
+                        name: aName,
+                        description: aDescription,
+                        type: SqlView.type.VIEW,
+                        sqlQuery: aSqlQuery,
+                    }),
+                })
+            )
+        })
+    })
+
+    describe('Edit', () => {
+        const renderForm = generateRenderer(
+            { section, mockSchema },
+            (routeOptions) => {
+                const attributes = [testCustomAttribute({ mandatory: false })]
+                const sqlView = testSqlViews({
+                    type: SqlView.type.VIEW,
+                    cacheStrategy: SqlView.cacheStrategy.NO_CACHE,
+                    sqlQuery: faker.lorem.sentence(),
+                    description: faker.lorem.sentence(),
+                })
+                const id = sqlView.id
+
+                const screen = render(
+                    <TestComponentWithRouter
+                        path={`/${section.namePlural}/:id`}
+                        initialEntries={[`/${section.namePlural}/${id}`]}
+                        customData={{
+                            attributes: () => ({ attributes }),
+                            sqlViews: (type: any, params: any) => {
+                                if (type === 'json-patch') {
+                                    updateMock(params)
+                                    return { statusCode: 204 }
+                                }
+                                if (type === 'read') {
+                                    if (params?.id) {
+                                        return sqlView
+                                    }
+                                    return { pager: { total: 0 }, sqlViews: [] }
+                                }
+                            },
+                        }}
+                        routeOptions={routeOptions}
+                    >
+                        <Edit />
+                    </TestComponentWithRouter>
+                )
+                return { screen, attributes, sqlView }
+            }
+        )
+
+        it('should contain all needed fields prefilled', async () => {
+            const { screen, sqlView } = await renderForm()
+
+            uiAssertions.expectNameFieldExist(sqlView.name, screen)
+            uiAssertions.expectTextAreaFieldToExist(
+                'description',
+                sqlView.description ?? '',
+                screen
+            )
+            const cacheStrategyField = screen.getByTestId(
+                'formfields-cacheStrategy'
+            )
+            const selectInput = within(cacheStrategyField).getByTestId(
+                'dhis2-uicore-select-input'
+            )
+            expect(selectInput).toHaveTextContent(
+                getConstantTranslation(sqlView.cacheStrategy)
+            )
+
+            uiAssertions.expectRadioFieldToExist(
+                'type',
+                [
+                    { label: 'View: SQL', checked: true },
+                    { label: 'Materialized view:', checked: false },
+                    { label: 'Query only:', checked: false },
+                ],
+                screen
+            )
+
+            uiAssertions.expectTextAreaFieldToExist(
+                'sqlQuery',
+                sqlView.sqlQuery,
+                screen
+            )
+        })
+
+        it('should have type radio group disabled in edit mode', async () => {
+            const { screen } = await renderForm()
+            const typeField = screen.getByTestId('formfields-type')
+            const radioButtons = within(typeField).getAllByRole('radio')
+            radioButtons.forEach((radio) => {
+                expect(radio).toBeDisabled()
+            })
+        })
+
+        it('should have a cancel button with a link back to the list view', async () => {
+            const { screen } = await renderForm()
+            const cancelButton = screen.getByTestId('form-cancel-link')
+            expect(cancelButton).toBeVisible()
+            expect(cancelButton).toHaveAttribute(
+                'href',
+                `/${section.namePlural}`
+            )
+        })
+
+        it('should do nothing and return to the list view on success when no field is changed', async () => {
+            const { screen } = await renderForm()
+            await uiActions.submitForm(screen)
+            expect(updateMock).not.toHaveBeenCalled()
+        })
+    })
+})

--- a/src/pages/sqlViews/New.tsx
+++ b/src/pages/sqlViews/New.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { FormBase } from '../../components'
+import { DefaultNewFormContents } from '../../components/form/DefaultFormContents'
+import { SECTIONS_MAP, useOnSubmitNew } from '../../lib'
+import { SqlViewFormFields, initialValues, validate } from './form'
+
+const section = SECTIONS_MAP.sqlView
+
+export const Component = () => {
+    return (
+        <FormBase
+            onSubmit={useOnSubmitNew({ section })}
+            initialValues={initialValues}
+            validate={validate}
+        >
+            <DefaultNewFormContents section={section}>
+                <SqlViewFormFields />
+            </DefaultNewFormContents>
+        </FormBase>
+    )
+}

--- a/src/pages/sqlViews/SqlViewActions.tsx
+++ b/src/pages/sqlViews/SqlViewActions.tsx
@@ -3,6 +3,7 @@ import i18n from '@dhis2/d2-i18n'
 import {
     Button,
     FlyoutMenu,
+    IconDuplicate16,
     IconEdit16,
     IconInfo16,
     IconLaunch16,
@@ -27,6 +28,7 @@ import {
     BaseListModel,
     TOOLTIPS,
     useLocationSearchState,
+    useModelSectionHandleOrThrow,
     useSchemaFromHandle,
     canDeleteModel,
     canEditModel,
@@ -88,6 +90,7 @@ export const useRunSqlView = () => {
                 errorAlert.show({
                     message: i18n.t('Could not run SQL view: {{error}}', {
                         error: errorMessage,
+                        nsSeparator: '~:~',
                     }),
                 })
                 return { success: false, errorMessage }
@@ -111,6 +114,7 @@ export const SqlViewActions = ({
 }: DefaultListActionProps & { onOpenResultsDrawer: (id: string) => void }) => {
     const sqlViewModel = model as SqlViewListModel
     const schema = useSchemaFromHandle()
+    const section = useModelSectionHandleOrThrow()
     const deletable = canDeleteModel(model)
     const editable = canEditModel(model)
     const shareable = schema.shareable
@@ -126,6 +130,10 @@ export const SqlViewActions = ({
         { pathname: model.id },
         { state: preservedSearchState }
     )
+    const handleDuplicateClick = useLinkClickHandler({
+        pathname: 'duplicate',
+        search: `?duplicatedId=${model.id}`,
+    })
 
     const isQuery = sqlViewModel.type === SqlView.type.QUERY
 
@@ -227,6 +235,23 @@ export const SqlViewActions = ({
                                     href={href}
                                 />
                             </TooltipWrapper>
+                            {section.duplicable && (
+                                <TooltipWrapper
+                                    condition={!editable}
+                                    content={TOOLTIPS.noDuplicateAccess}
+                                >
+                                    <MenuItem
+                                        dense
+                                        disabled={!editable}
+                                        label={i18n.t('Duplicate')}
+                                        icon={<IconDuplicate16 />}
+                                        onClick={(_, e) => {
+                                            handleDuplicateClick(e)
+                                            setOpen(false)
+                                        }}
+                                    />
+                                </TooltipWrapper>
+                            )}
                             <MenuItem
                                 dense
                                 label={i18n.t('Show details')}

--- a/src/pages/sqlViews/form/QueryDefinitionField.module.css
+++ b/src/pages/sqlViews/form/QueryDefinitionField.module.css
@@ -1,0 +1,161 @@
+.queryContainer {
+    display: flex;
+    justify-content: flex-start;
+    gap: var(--spacers-dp16);
+}
+
+.queryEditContainer {
+    min-width: 300px;
+    width: 100%;
+}
+
+.queryVariablesContainer {
+    min-width: 200px;
+    height: 325px;
+    overflow-y: auto;
+    border: 1px solid var(--colors-grey400);
+    border-radius: 5px;
+    margin-block-start: 22px;
+    padding: var(--spacers-dp8);
+}
+
+.queryFieldLabel {
+    font-size: 14px;
+    line-height: 19px;
+    display: block;
+    padding: 0px;
+}
+
+.templateVariablesText {
+    font-size: 13px;
+    color: var(--colors-grey700);
+    padding-block-end: var(--spacers-dp8);
+}
+
+.variableButton {
+    margin-block-end: var(--spacers-dp4);
+}
+
+.input {
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    gap: var(--spacers-dp8);
+    margin-top: 2px;
+}
+
+.inputError {
+    display: inline-flex;
+    align-items: center;
+    position: relative;
+    gap: var(--spacers-dp8);
+    margin-top: 2px;
+}
+
+.inputError:not(:focus) {
+    border-color: var(--colors-red500) !important;
+}
+
+.queryField {
+    display: flex;
+    align-items: center;
+}
+
+.queryField > input,
+.queryField > textarea {
+    box-sizing: border-box;
+
+    font-size: 14px;
+    line-height: 16px;
+    user-select: text;
+
+    color: var(--colors-grey900);
+    background-color: var(--colors-white);
+
+    padding: 11px 12px;
+    width: 100%;
+    outline: 0;
+    border: 1px solid;
+    border-color: var(--colors-grey500);
+    border-radius: 3px;
+    box-shadow: inset 0 0 1px 0 rgba(48, 54, 60, 0.1);
+    text-overflow: ellipsis;
+}
+
+.queryField > input {
+    max-height: 40px;
+}
+
+.queryField > textarea {
+    height: 325px;
+    resize: vertical;
+    line-height: 1.5;
+    font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco,
+        'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace;
+}
+
+.queryField > input.dense,
+.queryField > textarea.dense {
+    max-height: 32px;
+    padding: 7px 8px;
+}
+
+.queryField > input:focus,
+.queryField > textarea:focus {
+    outline: none;
+    box-shadow: inset 0 0 0 2px var(--theme-focus);
+    border-color: var(--theme-focus);
+}
+
+.queryField > input::placeholder,
+.queryField > textarea::placeholder {
+    color: var(--colors-grey600);
+    opacity: 1;
+}
+
+.queryField > input.warning,
+.queryField > textarea.warning {
+    border-color: var(--theme-warning);
+}
+
+.queryField > input.error,
+.queryField > textarea.error {
+    border-color: var(--theme-error);
+}
+
+.queryField > input.read-only,
+.queryField > textarea.read-only {
+    background-color: var(--colors-grey050);
+    border-color: var(--colors-grey300);
+    box-shadow: none;
+    cursor: text;
+}
+
+.queryField > input.disabled,
+.queryField > textarea.disabled {
+    background-color: var(--colors-grey100);
+    border-color: var(--colors-grey500);
+    color: var(--theme-disabled);
+    cursor: not-allowed;
+}
+
+.helpText {
+    margin: 4px 0 0 0;
+    font-size: 12px;
+    line-height: 14px;
+    color: var(--colors-grey700);
+}
+
+.errorStyling {
+    margin-block-start: 4px;
+    margin-block-end: 0px;
+    margin-inline: 0px;
+    font-size: 12px;
+    line-height: 14px;
+    color: var(--theme-error);
+}
+
+.errorIcon {
+    margin-inline-start: var(--spacers-dp8);
+    display: inline-block;
+}

--- a/src/pages/sqlViews/form/QueryDefinitionField.tsx
+++ b/src/pages/sqlViews/form/QueryDefinitionField.tsx
@@ -1,0 +1,149 @@
+import i18n from '@dhis2/d2-i18n'
+import { Button, IconErrorFilled24, theme } from '@dhis2/ui'
+import React, { useRef, useEffect, RefObject } from 'react'
+import { Field as FieldRFF, useField, FieldInputProps } from 'react-final-form'
+import { StandardFormField } from '../../../components'
+import styles from './QueryDefinitionField.module.css'
+
+export type SQLVariables = Record<string, { label: string }>
+
+const SQL_Variables: SQLVariables = {
+    _current_user_id: { label: i18n.t('Current user id') },
+    _current_username: { label: i18n.t('Current username') },
+}
+
+const insertElement = ({
+    id,
+    elementRef,
+    input,
+}: {
+    id: string
+    elementRef: RefObject<HTMLInputElement | HTMLTextAreaElement>
+    input: FieldInputProps<string>
+}): number | undefined => {
+    if (!elementRef.current) {
+        return
+    }
+
+    const elementText = '${' + id + '}'
+
+    const cursorStartIndex = elementRef.current.selectionStart ?? 0
+    const value = elementRef.current.value
+    const newText =
+        value.slice(0, cursorStartIndex) +
+        elementText +
+        value.slice(cursorStartIndex)
+    input.onChange(newText)
+
+    // force focus then blur to trigger rerun of validations
+    elementRef.current.focus()
+    elementRef.current.blur()
+    elementRef.current.focus()
+
+    return cursorStartIndex + elementText.length
+}
+
+export const QueryDefinitionField = ({ isQuery }: { isQuery: boolean }) => {
+    const { input: sqlQueryInput } = useField('sqlQuery')
+
+    const sqlQueryRef = useRef<HTMLTextAreaElement>(null)
+
+    const pendingCursorRef = useRef<{
+        elementRef: RefObject<HTMLInputElement | HTMLTextAreaElement>
+        position: number
+    } | null>(null)
+
+    useEffect(() => {
+        if (pendingCursorRef.current) {
+            const { elementRef, position } = pendingCursorRef.current
+            elementRef.current?.setSelectionRange(position, position)
+            pendingCursorRef.current = null
+        }
+    }, [pendingCursorRef.current])
+
+    return (
+        <div className={styles.queryContainer}>
+            <div className={styles.queryEditContainer}>
+                <StandardFormField>
+                    <FieldRFF name="sqlQuery">
+                        {({ input, meta }) => {
+                            const showError = meta.error && meta.touched
+                            return (
+                                <div data-test="formfields-sqlQuery">
+                                    <div className={styles.queryFieldLabel}>
+                                        {i18n.t('SQL query *')}
+                                    </div>
+                                    <div className={styles.queryField}>
+                                        <textarea
+                                            className={
+                                                showError
+                                                    ? styles.inputError
+                                                    : styles.input
+                                            }
+                                            {...input}
+                                            ref={sqlQueryRef}
+                                            aria-describedby="sqlQuery-help"
+                                        />
+                                        {showError && (
+                                            <div className={styles.errorIcon}>
+                                                <IconErrorFilled24
+                                                    color={theme.error}
+                                                />
+                                            </div>
+                                        )}
+                                    </div>
+                                    {showError && (
+                                        <div
+                                            className={styles.errorStyling}
+                                            data-test="formfields-sqlQuery-validation"
+                                        >
+                                            {meta.error}
+                                        </div>
+                                    )}
+                                    <p className={styles.helpText}>
+                                        {i18n.t(
+                                            'Only SELECT statements allowed. Sensitive tables, including user information, cannot be queried.'
+                                        )}
+                                    </p>
+                                </div>
+                            )
+                        }}
+                    </FieldRFF>
+                </StandardFormField>
+            </div>
+
+            {isQuery && (
+                <div className={styles.queryVariablesContainer}>
+                    <div className={styles.templateVariablesText}>
+                        {i18n.t('Insert a variable:', { nsSeparator: '~:~' })}
+                    </div>
+                    {Object.keys(SQL_Variables).map((v) => (
+                        <div key={v} className={styles.variableButton}>
+                            <Button
+                                secondary
+                                dataTest={`queryVariable_button_${v}`}
+                                small
+                                onClick={() => {
+                                    const elementRef = sqlQueryRef
+                                    const position = insertElement({
+                                        id: v,
+                                        elementRef,
+                                        input: sqlQueryInput,
+                                    })
+                                    if (position !== undefined) {
+                                        pendingCursorRef.current = {
+                                            elementRef,
+                                            position,
+                                        }
+                                    }
+                                }}
+                            >
+                                {SQL_Variables[v].label}
+                            </Button>
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/pages/sqlViews/form/SqlViewFormFields.tsx
+++ b/src/pages/sqlViews/form/SqlViewFormFields.tsx
@@ -1,0 +1,137 @@
+import i18n from '@dhis2/d2-i18n'
+import { FieldGroup, RadioFieldFF, SingleSelectFieldFF } from '@dhis2/ui'
+import React from 'react'
+import { Field, useField } from 'react-final-form'
+import { useParams } from 'react-router-dom'
+import {
+    StandardFormSection,
+    StandardFormSectionTitle,
+    StandardFormSectionDescription,
+    StandardFormField,
+    CustomAttributesSection,
+    NameField,
+    DescriptionField,
+} from '../../../components'
+import {
+    SCHEMA_SECTIONS,
+    useSchema,
+    getConstantTranslation,
+} from '../../../lib'
+import { SqlView } from '../../../types/generated'
+import { QueryDefinitionField } from './QueryDefinitionField'
+
+const section = SCHEMA_SECTIONS.sqlView
+
+export function SqlViewFormFields() {
+    const isEdit = !!useParams().id
+    const schema = useSchema(section.name)
+    const cacheStrategyOptions =
+        schema?.properties.cacheStrategy?.constants?.map((constant) => ({
+            value: constant,
+            label: getConstantTranslation(constant),
+        })) ?? []
+    const { input: typeInput } = useField('type')
+
+    return (
+        <>
+            <StandardFormSection>
+                <StandardFormSectionTitle>
+                    {i18n.t('Basic information')}
+                </StandardFormSectionTitle>
+
+                <StandardFormSectionDescription>
+                    {i18n.t(
+                        'Set up how this SQL view is identified and described.'
+                    )}
+                </StandardFormSectionDescription>
+
+                <StandardFormField>
+                    <NameField schemaSection={section} />
+                </StandardFormField>
+                <StandardFormField>
+                    <DescriptionField />
+                </StandardFormField>
+                <StandardFormField>
+                    <Field
+                        required
+                        component={SingleSelectFieldFF}
+                        inputWidth="400px"
+                        name="cacheStrategy"
+                        label={i18n.t('Cache strategy')}
+                        dataTest="formfields-cacheStrategy"
+                        options={cacheStrategyOptions}
+                        helpText={i18n.t(
+                            'Controls how long results are cached on the server before re-execution'
+                        )}
+                    />
+                </StandardFormField>
+            </StandardFormSection>
+
+            <StandardFormSection>
+                <StandardFormSectionTitle>
+                    {i18n.t('SQL definition')}
+                </StandardFormSectionTitle>
+
+                <StandardFormSectionDescription>
+                    {i18n.t('Choose the type of SQL view and write the query.')}
+                </StandardFormSectionDescription>
+
+                <StandardFormField>
+                    <FieldGroup
+                        label={i18n.t('SQL type')}
+                        required
+                        dataTest="formfields-type"
+                        helpText={
+                            isEdit
+                                ? i18n.t(
+                                      'SQL type cannot be changed after creation.'
+                                  )
+                                : undefined
+                        }
+                    >
+                        <Field<string | undefined>
+                            name="type"
+                            component={RadioFieldFF}
+                            label={i18n.t(
+                                'View: SQL query is stored in the database; results are generated each time.',
+                                { nsSeparator: '~:~' }
+                            )}
+                            type="radio"
+                            value={SqlView.type.VIEW}
+                            disabled={isEdit}
+                        />
+                        <Field<string | undefined>
+                            name="type"
+                            component={RadioFieldFF}
+                            label={i18n.t(
+                                'Materialized view: SQL query is stored, and results are cached.',
+                                { nsSeparator: '~:~' }
+                            )}
+                            type="radio"
+                            value={SqlView.type.MATERIALIZED_VIEW}
+                            disabled={isEdit}
+                        />
+                        <Field<string | undefined>
+                            name="type"
+                            component={RadioFieldFF}
+                            label={i18n.t(
+                                'Query only: Neither query nor results stored in the database. Supports inline $(variable) references.',
+                                { nsSeparator: '~:~' }
+                            )}
+                            type="radio"
+                            value={SqlView.type.QUERY}
+                            disabled={isEdit}
+                        />
+                    </FieldGroup>
+                </StandardFormField>
+                <StandardFormField>
+                    <QueryDefinitionField
+                        isQuery={typeInput.value === SqlView.type.QUERY}
+                    />
+                </StandardFormField>
+            </StandardFormSection>
+
+            <CustomAttributesSection schemaSection={section} />
+        </>
+    )
+}

--- a/src/pages/sqlViews/form/index.ts
+++ b/src/pages/sqlViews/form/index.ts
@@ -1,0 +1,2 @@
+export { SqlViewFormFields } from './SqlViewFormFields'
+export { sqlViewFormSchema, initialValues, validate } from './sqlViewSchema'

--- a/src/pages/sqlViews/form/sqlViewSchema.ts
+++ b/src/pages/sqlViews/form/sqlViewSchema.ts
@@ -1,16 +1,29 @@
 import { z } from 'zod'
-import { modelFormSchemas } from '../../../lib'
+import {
+    getDefaultsOld,
+    modelFormSchemas,
+    createFormValidate,
+} from '../../../lib'
 import { SqlView } from '../../../types/generated'
 
-const { withDefaultListColumns } = modelFormSchemas
+const { identifiable, withAttributeValues, withDefaultListColumns } =
+    modelFormSchemas
 
-const sqlViewBaseSchema = z.object({
-    type: z.nativeEnum(SqlView.type),
-    cacheStrategy: z.nativeEnum(SqlView.cacheStrategy),
-    sqlQuery: z.string(),
-})
-export const sqlViewListSchema = sqlViewBaseSchema
-    .merge(withDefaultListColumns)
-    .extend({
-        code: z.string().optional(),
+const sqlViewBaseSchema = z
+    .object({
+        type: z.nativeEnum(SqlView.type).default(SqlView.type.VIEW),
+        cacheStrategy: z
+            .nativeEnum(SqlView.cacheStrategy)
+            .default(SqlView.cacheStrategy.RESPECT_SYSTEM_SETTING),
+        sqlQuery: z.string(),
+        description: z.string().trim().optional(),
     })
+    .merge(identifiable)
+
+export const sqlViewListSchema = sqlViewBaseSchema.merge(withDefaultListColumns)
+
+export const sqlViewFormSchema = sqlViewBaseSchema.merge(withAttributeValues)
+
+export const initialValues = getDefaultsOld(sqlViewFormSchema)
+
+export const validate = createFormValidate(sqlViewFormSchema)

--- a/src/pages/sqlViews/form/sqlViewSchema.ts
+++ b/src/pages/sqlViews/form/sqlViewSchema.ts
@@ -1,9 +1,6 @@
 import { z } from 'zod'
-import {
-    getDefaultsOld,
-    modelFormSchemas,
-    createFormValidate,
-} from '../../../lib'
+import { modelFormSchemas, createFormValidate } from '../../../lib'
+import { getDefaults } from '../../../lib/zod/getDefaults'
 import { SqlView } from '../../../types/generated'
 
 const { identifiable, withAttributeValues, withDefaultListColumns } =
@@ -11,10 +8,8 @@ const { identifiable, withAttributeValues, withDefaultListColumns } =
 
 const sqlViewBaseSchema = z
     .object({
-        type: z.nativeEnum(SqlView.type).default(SqlView.type.VIEW),
-        cacheStrategy: z
-            .nativeEnum(SqlView.cacheStrategy)
-            .default(SqlView.cacheStrategy.RESPECT_SYSTEM_SETTING),
+        type: z.nativeEnum(SqlView.type),
+        cacheStrategy: z.nativeEnum(SqlView.cacheStrategy),
         sqlQuery: z.string(),
         description: z.string().trim().optional(),
     })
@@ -24,6 +19,9 @@ export const sqlViewListSchema = sqlViewBaseSchema.merge(withDefaultListColumns)
 
 export const sqlViewFormSchema = sqlViewBaseSchema.merge(withAttributeValues)
 
-export const initialValues = getDefaultsOld(sqlViewFormSchema)
+export const initialValues = getDefaults(sqlViewFormSchema, {
+    type: SqlView.type.VIEW,
+    cacheStrategy: SqlView.cacheStrategy.RESPECT_SYSTEM_SETTING,
+})
 
 export const validate = createFormValidate(sqlViewFormSchema)


### PR DESCRIPTION
Adds new, edit, duplicate view of sql view form. See https://dhis2.atlassian.net/browse/DHIS2-21243

Very slight visual difference from Joe's prototype: I've added a box around the variables you can insert (this hence matches the layout for message templates):
<img width="1115" height="572" alt="image" src="https://github.com/user-attachments/assets/3beb1634-41fb-49a8-bcb8-4935ed8f73b6" />
