### PR TITLE
chore: testing reruns

### DIFF
--- a/src/pages/dataElementGroups/List.spec.tsx
+++ b/src/pages/dataElementGroups/List.spec.tsx
@@ -8,6 +8,8 @@ import {
 import { generateDefaultListTests } from '../defaultListTests'
 import { Component } from './List'
 
+jest.retryTimes(2, { logErrorsBeforeRetry: true })
+
 const section = SECTIONS_MAP.dataElementGroup
 const mockSchema = schemaMock
 const ComponentToTest = Component

--- a/src/pages/dataElements/Form.spec.tsx
+++ b/src/pages/dataElements/Form.spec.tsx
@@ -31,6 +31,8 @@ import { Component as Edit } from './Edit'
 import { Component as New } from './New'
 import resetAllMocks = jest.resetAllMocks
 
+jest.retryTimes(2, { logErrorsBeforeRetry: true })
+
 const section = SECTIONS_MAP.dataElement
 const mockSchema = schemaMock
 jest.mock('use-debounce', () => ({

--- a/src/pages/organisationUnits/List.spec.tsx
+++ b/src/pages/organisationUnits/List.spec.tsx
@@ -17,6 +17,8 @@ import TestComponentWithRouter from '../../testUtils/TestComponentWithRouter'
 import type { OrganisationUnit } from '../../types/generated'
 import { Component as OrgUnitsList } from './List'
 
+jest.retryTimes(2, { logErrorsBeforeRetry: true })
+
 const deleteOrgUnitMock = jest.fn()
 const renderList = async ({
     rootOrgUnits = [testOrgUnit()] as Partial<OrganisationUnit>[],

--- a/src/pages/trackedEntityTypes/List.spec.tsx
+++ b/src/pages/trackedEntityTypes/List.spec.tsx
@@ -10,6 +10,8 @@ const ComponentToTest = Component
 const generateRandomElement = testTrackedEntityType
 const customData = {}
 
+jest.retryTimes(2, { logErrorsBeforeRetry: true })
+
 generateDefaultListTests({
     section,
     mockSchema,

--- a/src/pages/validationRules/List.spec.tsx
+++ b/src/pages/validationRules/List.spec.tsx
@@ -10,6 +10,8 @@ const ComponentToTest = Component
 const generateRandomElement = testValidationRule
 const customData = {}
 
+jest.retryTimes(2, { logErrorsBeforeRetry: true })
+
 generateDefaultListTests({
     section,
     mockSchema,


### PR DESCRIPTION
As discussed in our meeting on Tuesday, 19 May:

- the easiest way to rerun tests in individual test files is to add `jest.retryTimes(2)` at the top of the file. This will then cause the test to rerun up to the specified number of times. 
- there are more comprehensive solutions that would let us rerun failing tests but these involve more change in CI configuration which I think is a bit more difficult given our reuse of CI workflows across apps

Proposal is that we add this `jest.retryTimes(2, { logErrorsBeforeRetry: true })` (with logging so ideally we see if it had to run twice to pass) to tests as we notice flakiness (e.g. if a test fails, but it has passed before, then you can add this to work around flaky tests to try to prevent cases where we rerun all tests to get a pass before merging.

Concurrently, we should try to fix the flaky tests (or underlying code) (probably by assigning to Claude to run the test repeatedly and identify the source of the flakiness. 