### PR TITLE
fix: filter out child sections by api version [DHIS2-21547]

### DIFF
--- a/src/lib/sections/sectionAuthorities.ts
+++ b/src/lib/sections/sectionAuthorities.ts
@@ -16,6 +16,8 @@ import {
     isNonCreateableSchema,
     useCurrentUserAuthorities,
 } from '../user'
+import { useIsSectionFeatureToggle } from './sectionFeatureToggle'
+
 type UserAuthorities = ReturnType<typeof useCurrentUserAuthorities>
 
 const isNonCreateableSection = (section: Section): section is SchemaSection => {
@@ -62,6 +64,7 @@ export const useIsSectionAuthorizedPredicate = () => {
     const userAuthorities = useCurrentUserAuthorities()
     const schemas = useSchemas()
     const requireCreateAuthToView = useSystemSetting('keyRequireAddToView')
+    const isSectionFeatureToggled = useIsSectionFeatureToggle()
 
     const isSectionAuthorizedPredicate = useCallback(
         (section: Section): boolean => {
@@ -90,8 +93,10 @@ export const useIsSectionAuthorizedPredicate = () => {
                     (childSection) =>
                         childSection.parentSectionKey === section.name
                 )
-                return childSections.some((childSection) =>
-                    isSectionAuthorizedPredicate(childSection)
+                return childSections.some(
+                    (childSection) =>
+                        isSectionFeatureToggled(childSection) &&
+                        isSectionAuthorizedPredicate(childSection)
                 )
             }
             return canCreateModelInSection(section, userAuthorities, schemas)


### PR DESCRIPTION
See https://dhis2.atlassian.net/browse/DHIS2-21547

This actually no manifests itself as a problem because the updates to include icons mean that every user will have access to something in "others" section.

However, the underlying bug for the issue is still relevant (we were checking to show a parent sidebar section by checking if any child sections were accessible without first filtering out the child sections by api version). So this fix adds logic to first check if the section is feature toggled, and then checks if user is authorised to view that section.