### PR TITLE
fix: add custom attributes to data set section [DHIS2-7765]

### DIFF
--- a/src/pages/dataSets/form/dataEntryForm/sectionForm/DataSetSectionForm.tsx
+++ b/src/pages/dataSets/form/dataEntryForm/sectionForm/DataSetSectionForm.tsx
@@ -36,6 +36,7 @@ export const fieldFilters = [
     'displayOptions',
     'dataElements[id,displayName,categoryCombo[id]]',
     'greyedFields[dataElement, categoryOptionCombo]',
+    'attributeValues[value,attribute[id]]',
 ] as const
 
 const dataSetSectionSchemaSection = {
@@ -101,7 +102,7 @@ export const DataSetSectionForm = ({
             initialValues={{ ...initialValues, dataSet: { id: dataSetId } }}
             onSubmit={onSubmit}
             valueFormatter={valueFormatter}
-            includeAttributes={false}
+            section={dataSetSectionSchemaSection}
             mutators={{ ...arrayMutators }}
         >
             <DataSetSectionFormContents onCancel={onCancel} />

--- a/src/pages/dataSets/form/dataEntryForm/sectionForm/DataSetSectionFormContents.tsx
+++ b/src/pages/dataSets/form/dataEntryForm/sectionForm/DataSetSectionFormContents.tsx
@@ -19,6 +19,7 @@ import {
 import { useParams } from 'react-router-dom'
 import {
     CodeField,
+    CustomAttributesSection,
     DescriptionField,
     DrawerFormFooter,
     DrawerLayout,
@@ -381,6 +382,11 @@ export const DataSetSectionFormContents = ({
                         </StandardFormField>
                     </div>
                 </SectionedFormSection>
+
+                <CustomAttributesSection
+                    schemaSection={dataSetSectionSchemaSection}
+                    sectionedLayout={true}
+                />
             </SectionedFormSections>
             <SectionedFormErrorNotice />
         </>


### PR DESCRIPTION
Fix attribute:

- Attributes: choosing Applies to Section
- Add custom attributes into Data set Section Form

[DHIS2-7765](https://dhis2.atlassian.net/browse/DHIS2-7765)

_Custom attributes (data set section form)_
<img width="1143" height="961" alt="image" src="https://github.com/user-attachments/assets/813f6dd4-6317-4438-a526-921bd2d4f51f" />


[DHIS2-7765]: https://dhis2.atlassian.net/browse/DHIS2-7765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ