### PR TITLE
chore: drawer add new tests [DHIS2-21687]

### DIFF
--- a/src/components/form/DefaultFormContents.tsx
+++ b/src/components/form/DefaultFormContents.tsx
@@ -13,6 +13,7 @@ type DefaultFormContentsProps = {
     readonly children: React.ReactNode
     readonly section: ModelSection
     readonly footer?: React.ReactNode
+    readonly dataTest?: string
 }
 
 function DefaultFormContents({
@@ -21,6 +22,7 @@ function DefaultFormContents({
     showTranslatedFieldsNotice = false,
     showCloneNotice = false,
     footer,
+    dataTest,
 }: DefaultFormContentsProps & {
     readonly showTranslatedFieldsNotice?: boolean
     readonly showCloneNotice?: boolean
@@ -28,7 +30,7 @@ function DefaultFormContents({
     const listPath = `/${getSectionPath(section)}`
 
     return (
-        <>
+        <div data-test={dataTest}>
             <div className={classes.form}>
                 {showTranslatedFieldsNotice && <TranslatedFieldsNoticeBox />}
                 {showCloneNotice && <CloneNoticeBox section={section} />}
@@ -38,7 +40,7 @@ function DefaultFormContents({
                 </StandardFormSection>
             </div>
             {footer ?? <DefaultFormFooter cancelTo={listPath} />}
-        </>
+        </div>
     )
 }
 

--- a/src/pages/attributes/Form.spec.tsx
+++ b/src/pages/attributes/Form.spec.tsx
@@ -47,6 +47,7 @@ const OBJECT_OPTIONS = Object.values(ATTRIBUTE_TRANSLATIONS).map((a) => ({
 describe('Attributes form tests', () => {
     const createMock = jest.fn()
     const updateMock = jest.fn()
+    const optionSetCreateMock = jest.fn()
     beforeEach(() => {
         resetAllMocks()
         const portalRoot = document.createElement('div')
@@ -73,7 +74,19 @@ describe('Attributes form tests', () => {
                     <TestComponentWithRouter
                         path={`/${section.namePlural}`}
                         customData={{
-                            optionSets: () => ({ optionSets }),
+                            optionSets: (type: any, params: any) => {
+                                if (type === 'create') {
+                                    optionSetCreateMock(params)
+                                    return { statusCode: 204 }
+                                }
+                                if (type === 'read') {
+                                    return {
+                                        optionSets,
+                                        // this is a bit hacky, but prevents problems with uniqueness validation when submitting option set form
+                                        pager: { total: 0 },
+                                    }
+                                }
+                            },
                             attributes: (type: any, params: any) => {
                                 if (type === 'create') {
                                     createMock(params)
@@ -183,12 +196,27 @@ describe('Attributes form tests', () => {
             expect(
                 await screen.findByText('Add new Option set')
             ).toBeInTheDocument()
-            expect(screen.getByTestId('optionSetNewForm')).toBeInTheDocument()
-            expect(
-                within(screen.getByTestId('optionSetNewForm')).getByTestId(
-                    'form-submit-button'
-                )
-            ).toHaveTextContent('Save and close')
+
+            const drawerForm = screen.getByTestId('optionSetNewForm')
+            const submitButton =
+                within(drawerForm).getByTestId('form-submit-button')
+            expect(submitButton).toHaveTextContent('Save and close')
+
+            const nameInput = within(drawerForm)
+                .getByTestId('formfields-name')
+                .querySelector('input') as HTMLInputElement
+            const optName = faker.animal.bird()
+            await userEvent.type(nameInput, optName)
+
+            await userEvent.click(submitButton)
+
+            // check that the appropriate resource (optionSet) was called with entered optionSet form values
+            expect(optionSetCreateMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    data: expect.objectContaining({ name: optName }),
+                    resource: 'optionSets',
+                })
+            )
         })
     })
     describe('New', () => {

--- a/src/pages/categoryCombos/New.tsx
+++ b/src/pages/categoryCombos/New.tsx
@@ -29,7 +29,11 @@ export const Component = ({
             includeAttributes={false}
             section={section}
         >
-            <DefaultNewFormContents section={section} footer={footer}>
+            <DefaultNewFormContents
+                section={section}
+                footer={footer}
+                dataTest="categoryComboNewForm"
+            >
                 <CategoryComboFormFields />
             </DefaultNewFormContents>
         </FormBase>

--- a/src/pages/categoryOptionGroupSets/New.tsx
+++ b/src/pages/categoryOptionGroupSets/New.tsx
@@ -27,7 +27,11 @@ export const Component = ({
             validate={validate}
             section={section}
         >
-            <DefaultNewFormContents section={section} footer={footer}>
+            <DefaultNewFormContents
+                section={section}
+                footer={footer}
+                dataTest="categoryOptionGroupSetNewForm"
+            >
                 <CategoryOptionGroupSetFormFields />
             </DefaultNewFormContents>
         </FormBase>

--- a/src/pages/dataApprovalLevels/Form.spec.tsx
+++ b/src/pages/dataApprovalLevels/Form.spec.tsx
@@ -1,9 +1,12 @@
 import { faker } from '@faker-js/faker'
-import { render, waitFor } from '@testing-library/react'
+import { act, render, waitFor, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
+import categoryOptionGroupSetSchemaMock from '../../__mocks__/schema/categoriesOptionGroupSetsSchema.json'
 import schemaMock from '../../__mocks__/schema/dataApprovalLevel.json'
 import { FOOTER_ID } from '../../app/layout/Layout'
-import { SECTIONS_MAP } from '../../lib'
+import { ModelSchemas, SECTIONS_MAP } from '../../lib'
+import { useSchemaStore } from '../../lib/schemas/schemaStore'
 import {
     randomDhis2Id,
     randomLongString,
@@ -86,6 +89,7 @@ describe('Data approval levels form tests', () => {
                                 categoryOptionGroupSets,
                                 pager: {},
                             }),
+                            attributes: () => ({ attributes: [] }),
                             dataApprovalLevels: (type: any, params: any) => {
                                 if (type === 'create') {
                                     createMock(params)
@@ -155,6 +159,39 @@ describe('Data approval levels form tests', () => {
             )
             await uiActions.submitForm(screen)
             expect(createMock).not.toHaveBeenCalled()
+        })
+
+        it('should open the category option group set new form in a drawer when clicking the "Add new" button', async () => {
+            const { screen } = await renderForm()
+
+            useSchemaStore.getState().setSchemas({
+                ...useSchemaStore.getState().schemas,
+                categoryOptionGroupSet: categoryOptionGroupSetSchemaMock,
+            } as unknown as ModelSchemas)
+
+            // Flush the useEffect dynamic import in ModelSingleSelectRefreshableFormField
+            await act(async () => {})
+
+            const categoryOptionGroupSetField = screen.getByTestId(
+                'formfields-categoryoptiongroupset'
+            )
+
+            const addNewButton = within(
+                categoryOptionGroupSetField
+            ).getAllByRole('button')[1]
+            await userEvent.click(addNewButton)
+
+            expect(
+                await screen.findByText('Add new Category option group set')
+            ).toBeInTheDocument()
+            expect(
+                screen.getByTestId('categoryOptionGroupSetNewForm')
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    screen.getByTestId('categoryOptionGroupSetNewForm')
+                ).getByTestId('form-submit-button')
+            ).toHaveTextContent('Save and close')
         })
 
         it('should show an error if the org unit level and category option group set combination already exists', async () => {

--- a/src/pages/dataApprovalWorkflows/Form.spec.tsx
+++ b/src/pages/dataApprovalWorkflows/Form.spec.tsx
@@ -1,9 +1,16 @@
 import { faker } from '@faker-js/faker'
-import { render, waitFor } from '@testing-library/react'
+import { act, render, waitFor, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
+import categoryCombosSchema from '../../__mocks__/schema/categoryCombosSchema.json'
 import schemaMock from '../../__mocks__/schema/dataApprovalWorkflowSchema.json'
 import { FOOTER_ID } from '../../app/layout/Layout'
-import { DEFAULT_CATEGORYCOMBO_SELECT_OPTION, SECTIONS_MAP } from '../../lib'
+import {
+    DEFAULT_CATEGORYCOMBO_SELECT_OPTION,
+    ModelSchemas,
+    SECTIONS_MAP,
+} from '../../lib'
+import { useSchemaStore } from '../../lib/schemas/schemaStore'
 import {
     randomDhis2Id,
     randomLongString,
@@ -155,6 +162,38 @@ describe('Data approval workflows form tests', () => {
             )
             await uiActions.submitForm(screen)
             expect(createMock).not.toHaveBeenCalled()
+        })
+
+        it('should open the category combo new form in a drawer when clicking the "Add new" button', async () => {
+            const { screen } = await renderForm()
+
+            useSchemaStore.getState().setSchemas({
+                ...useSchemaStore.getState().schemas,
+                categoryCombo: categoryCombosSchema,
+            } as unknown as ModelSchemas)
+
+            // Flush the useEffect dynamic import in ModelSingleSelectRefreshableFormField
+            await act(async () => {})
+
+            const categoryComboField = screen.getByTestId(
+                'formfields-categorycombo'
+            )
+
+            const addNewButton =
+                within(categoryComboField).getAllByRole('button')[1]
+            await userEvent.click(addNewButton)
+
+            expect(
+                await screen.findByText('Add new Category combination')
+            ).toBeInTheDocument()
+            expect(
+                screen.getByTestId('categoryComboNewForm')
+            ).toBeInTheDocument()
+            expect(
+                within(screen.getByTestId('categoryComboNewForm')).getByTestId(
+                    'form-submit-button'
+                )
+            ).toHaveTextContent('Save and close')
         })
     })
 

--- a/src/pages/dataElements/Form.spec.tsx
+++ b/src/pages/dataElements/Form.spec.tsx
@@ -1,17 +1,21 @@
 import { faker } from '@faker-js/faker'
-import { render, within, waitFor } from '@testing-library/react'
+import { act, render, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import categoryCombosSchema from '../../__mocks__/schema/categoryCombosSchema.json'
 import schemaMock from '../../__mocks__/schema/dataElements.json'
+import optionSetSchemaMock from '../../__mocks__/schema/optionSet.json'
 import { FOOTER_ID } from '../../app/layout/Layout'
 import { DISABLING_VALUE_TYPES } from '../../components/form/fields/AggregationTypeFieldByValueType'
 import {
     DEFAULT_CATEGORY_COMBO,
     DEFAULT_CATEGORYCOMBO_SELECT_OPTION,
     getConstantTranslation,
+    ModelSchemas,
     SECTIONS_MAP,
     VALUE_TYPE,
 } from '../../lib'
+import { useSchemaStore } from '../../lib/schemas/schemaStore'
 import {
     randomLongString,
     randomValueIn,
@@ -332,6 +336,95 @@ describe('Data elements form tests', () => {
             )
             expect(multiTextOptions).toHaveLength(0)
         })
+        it('should open the category combo new form in a drawer when clicking the "Add new" button', async () => {
+            const { screen } = await renderForm()
+
+            useSchemaStore.getState().setSchemas({
+                ...useSchemaStore.getState().schemas,
+                categoryCombo: categoryCombosSchema,
+            } as unknown as ModelSchemas)
+
+            // Flush the useEffect dynamic import in ModelSingleSelectRefreshableFormField
+            await act(async () => {})
+
+            const categoryComboField = screen.getByTestId(
+                'formfields-categorycombo'
+            )
+
+            const addNewButton =
+                within(categoryComboField).getAllByRole('button')[1]
+            await userEvent.click(addNewButton)
+
+            expect(
+                await screen.findByText('Add new Category combination')
+            ).toBeInTheDocument()
+            expect(
+                screen.getByTestId('categoryComboNewForm')
+            ).toBeInTheDocument()
+            expect(
+                within(screen.getByTestId('categoryComboNewForm')).getByTestId(
+                    'form-submit-button'
+                )
+            ).toHaveTextContent('Save and close')
+        })
+
+        it('should open the option set new form in a drawer when clicking the "Add new" button', async () => {
+            const { screen } = await renderForm()
+
+            useSchemaStore.getState().setSchemas({
+                ...useSchemaStore.getState().schemas,
+                optionSet: optionSetSchemaMock,
+            } as unknown as ModelSchemas)
+
+            // Flush the useEffect dynamic import in ModelSingleSelectRefreshableFormField
+            await act(async () => {})
+
+            const optionSetField = screen.getByTestId('formfields-optionset')
+            const addNewButton =
+                within(optionSetField).getAllByRole('button')[1]
+            await userEvent.click(addNewButton)
+
+            expect(
+                await screen.findByText('Add new Option set')
+            ).toBeInTheDocument()
+            expect(screen.getByTestId('optionSetNewForm')).toBeInTheDocument()
+            expect(
+                within(screen.getByTestId('optionSetNewForm')).getByTestId(
+                    'form-submit-button'
+                )
+            ).toHaveTextContent('Save and close')
+        })
+
+        it('should open the option set new form in a drawer when clicking the "Add new" button on the comment option set field', async () => {
+            const { screen } = await renderForm()
+
+            useSchemaStore.getState().setSchemas({
+                ...useSchemaStore.getState().schemas,
+                optionSet: optionSetSchemaMock,
+            } as unknown as ModelSchemas)
+
+            // Flush the useEffect dynamic import in ModelSingleSelectRefreshableFormField
+            await act(async () => {})
+
+            const commentOptionSetField = screen.getByTestId(
+                'formfields-commentoptionset'
+            )
+            const addNewButton = within(commentOptionSetField).getAllByRole(
+                'button'
+            )[1]
+            await userEvent.click(addNewButton)
+
+            expect(
+                await screen.findByText('Add new Option set')
+            ).toBeInTheDocument()
+            expect(screen.getByTestId('optionSetNewForm')).toBeInTheDocument()
+            expect(
+                within(screen.getByTestId('optionSetNewForm')).getByTestId(
+                    'form-submit-button'
+                )
+            ).toHaveTextContent('Save and close')
+        })
+
         it('should change the value type accordingly when an option set is selected', async () => {
             const { screen, optionSets } = await renderForm()
 

--- a/src/pages/dataSets/Form.spec.tsx
+++ b/src/pages/dataSets/Form.spec.tsx
@@ -1,6 +1,8 @@
 describe('Data set form tests', () => {
     describe('Common', () => {
         it('should not submit when a required values is missing ', () => {})
+        it('should open the option set new form in a categoryCombo when clicking the "Add new" button  ', () => {})
+        it('should open the option set new form in a approvalWorkflow when clicking the "Add new" button  ', () => {})
     })
     describe('New', () => {
         it('contain all needed field', () => {})

--- a/src/pages/indicatorTypes/New.tsx
+++ b/src/pages/indicatorTypes/New.tsx
@@ -29,7 +29,11 @@ export const Component = ({
             includeAttributes={false}
             section={section}
         >
-            <DefaultNewFormContents section={section} footer={footer}>
+            <DefaultNewFormContents
+                section={section}
+                footer={footer}
+                dataTest="indicatorTypeNewForm"
+            >
                 <IndicatorTypesFormFields section={section} />
             </DefaultNewFormContents>
         </FormBase>

--- a/src/pages/indicators/Form.spec.tsx
+++ b/src/pages/indicators/Form.spec.tsx
@@ -1,10 +1,12 @@
 import { faker } from '@faker-js/faker'
-import { render, within } from '@testing-library/react'
+import { act, render, within } from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import schemaMock from '../../__mocks__/schema/indicators.json'
+import indicatorTypesSchemaMock from '../../__mocks__/schema/indicatorTypes.json'
 import { FOOTER_ID } from '../../app/layout/Layout'
-import { SECTIONS_MAP } from '../../lib'
+import { ModelSchemas, SECTIONS_MAP } from '../../lib'
+import { useSchemaStore } from '../../lib/schemas/schemaStore'
 import {
     randomDhis2Id,
     randomLongString,
@@ -346,6 +348,38 @@ describe('Indicators form tests', () => {
             )
             await uiActions.submitForm(screen)
             expect(createMock).not.toHaveBeenCalled()
+        })
+
+        it('should open the indicator type new form in a drawer when clicking the "Add new" button', async () => {
+            const { screen } = await renderForm()
+
+            useSchemaStore.getState().setSchemas({
+                ...useSchemaStore.getState().schemas,
+                indicatorType: indicatorTypesSchemaMock,
+            } as unknown as ModelSchemas)
+
+            // Flush the useEffect dynamic import in ModelSingleSelectRefreshableFormField
+            await act(async () => {})
+
+            const indicatorTypeField = screen.getByTestId(
+                'formfields-indicatortype'
+            )
+
+            const addNewButton =
+                within(indicatorTypeField).getAllByRole('button')[1]
+            await userEvent.click(addNewButton)
+
+            expect(
+                await screen.findByText('Add new Indicator type')
+            ).toBeInTheDocument()
+            expect(
+                screen.getByTestId('indicatorTypeNewForm')
+            ).toBeInTheDocument()
+            expect(
+                within(screen.getByTestId('indicatorTypeNewForm')).getByTestId(
+                    'form-submit-button'
+                )
+            ).toHaveTextContent('Save and close')
         })
     })
 

--- a/src/pages/optionGroupSets/Form.spec.tsx
+++ b/src/pages/optionGroupSets/Form.spec.tsx
@@ -1,9 +1,12 @@
 import { faker } from '@faker-js/faker'
-import { render } from '@testing-library/react'
+import { act, render, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import schemaMock from '../../__mocks__/schema/optionGroupSetsSchema.json'
+import optionSetSchemaMock from '../../__mocks__/schema/optionSet.json'
 import { FOOTER_ID } from '../../app/layout/Layout'
-import { SECTIONS_MAP } from '../../lib'
+import { ModelSchemas, SECTIONS_MAP } from '../../lib'
+import { useSchemaStore } from '../../lib/schemas/schemaStore'
 import {
     randomLongString,
     testCustomAttribute,
@@ -145,6 +148,33 @@ describe('Option group sets form tests', () => {
             )
             await uiActions.submitForm(screen)
             expect(createMock).not.toHaveBeenCalled()
+        })
+
+        it('should open the option set new form in a drawer when clicking the "Add new" button', async () => {
+            const { screen } = await renderForm()
+
+            useSchemaStore.getState().setSchemas({
+                ...useSchemaStore.getState().schemas,
+                optionSet: optionSetSchemaMock,
+            } as unknown as ModelSchemas)
+
+            // Flush the useEffect dynamic import in ModelSingleSelectRefreshableFormField
+            await act(async () => {})
+
+            const optionSetField = screen.getByTestId('formfields-optionSet')
+            const addNewButton =
+                within(optionSetField).getAllByRole('button')[1]
+            await userEvent.click(addNewButton)
+
+            expect(
+                await screen.findByText('Add new Option set')
+            ).toBeInTheDocument()
+            expect(screen.getByTestId('optionSetNewForm')).toBeInTheDocument()
+            expect(
+                within(screen.getByTestId('optionSetNewForm')).getByTestId(
+                    'form-submit-button'
+                )
+            ).toHaveTextContent('Save and close')
         })
     })
     describe('New', () => {

--- a/src/pages/optionGroups/Form.spec.tsx
+++ b/src/pages/optionGroups/Form.spec.tsx
@@ -1,9 +1,12 @@
 import { faker } from '@faker-js/faker'
-import { render } from '@testing-library/react'
+import { act, render, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import schemaMock from '../../__mocks__/schema/optionGroups.json'
+import optionSetSchemaMock from '../../__mocks__/schema/optionSet.json'
 import { FOOTER_ID } from '../../app/layout/Layout'
-import { SECTIONS_MAP } from '../../lib'
+import { ModelSchemas, SECTIONS_MAP } from '../../lib'
+import { useSchemaStore } from '../../lib/schemas/schemaStore'
 import {
     randomDhis2Id,
     randomLongString,
@@ -93,6 +96,37 @@ describe('OptionGroups form tests', () => {
             await uiAssertions.expectNameToErrorWhenExceedsLength(screen)
             await uiActions.submitForm(screen)
             expect(createMock).not.toHaveBeenCalled()
+        })
+
+        it('should open the option set new form in a drawer when clicking the "Add new" button', async () => {
+            const { screen } = await renderForm({
+                customTestData: {
+                    attributes: () => ({ attributes: [] }),
+                },
+            })
+
+            useSchemaStore.getState().setSchemas({
+                ...useSchemaStore.getState().schemas,
+                optionSet: optionSetSchemaMock,
+            } as unknown as ModelSchemas)
+
+            // Flush the useEffect dynamic import in ModelSingleSelectRefreshableFormField
+            await act(async () => {})
+
+            const optionSetField = screen.getByTestId('formfields-optionSet')
+            const addNewButton =
+                within(optionSetField).getAllByRole('button')[1]
+            await userEvent.click(addNewButton)
+
+            expect(
+                await screen.findByText('Add new Option set')
+            ).toBeInTheDocument()
+            expect(screen.getByTestId('optionSetNewForm')).toBeInTheDocument()
+            expect(
+                within(screen.getByTestId('optionSetNewForm')).getByTestId(
+                    'form-submit-button'
+                )
+            ).toHaveTextContent('Save and close')
         })
     })
 

--- a/src/pages/predictors/Form.spec.tsx
+++ b/src/pages/predictors/Form.spec.tsx
@@ -1,0 +1,3 @@
+describe('Common', () => {
+    it.skip('should open the dataElement new form in a drawer when clicking the "Add new" button', () => {})
+})

--- a/src/pages/programRuleVariables/Form.spec.tsx
+++ b/src/pages/programRuleVariables/Form.spec.tsx
@@ -1,4 +1,10 @@
-import { render, waitFor, type RenderResult } from '@testing-library/react'
+import {
+    act,
+    render,
+    waitFor,
+    within,
+    type RenderResult,
+} from '@testing-library/react'
 import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import schemaMock from '../../__mocks__/schema/programRuleVariablesSchema.json'
@@ -308,6 +314,34 @@ describe('Program Rule Variable form tests', () => {
                     'Required',
                     screen
                 )
+            })
+        })
+
+        describe('Program "Add new" button', () => {
+            it('should open a new tab when clicking "Add new" for programs instead of opening a drawer', async () => {
+                const { screen } = await renderForm()
+
+                const windowOpenSpy = jest
+                    .spyOn(window, 'open')
+                    .mockImplementation(() => null)
+
+                // Flush the useEffect so LINK_ONLY_SECTIONS check runs and NewItemForm stays undefined
+                await act(async () => {})
+
+                const programField = screen.getByTestId('program-field')
+                const addNewButton =
+                    within(programField).getAllByRole('button')[1]
+                await userEvent.click(addNewButton)
+
+                expect(windowOpenSpy).toHaveBeenCalledWith(
+                    expect.stringContaining('/programs/new'),
+                    '_blank'
+                )
+                expect(
+                    screen.queryByText('Add new Program')
+                ).not.toBeInTheDocument()
+
+                windowOpenSpy.mockRestore()
             })
         })
     })

--- a/src/pages/relationshipTypes/Form.spec.tsx
+++ b/src/pages/relationshipTypes/Form.spec.tsx
@@ -1,9 +1,12 @@
 import { faker } from '@faker-js/faker'
-import { render } from '@testing-library/react'
+import { act, render, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import schemaMock from '../../__mocks__/schema/relationshipTypes.json'
+import trackedEntityTypesSchemaMock from '../../__mocks__/schema/trackedEntityTypes.json'
 import { FOOTER_ID } from '../../app/layout/Layout'
-import { SECTIONS_MAP } from '../../lib'
+import { ModelSchemas, SECTIONS_MAP } from '../../lib'
+import { useSchemaStore } from '../../lib/schemas/schemaStore'
 import {
     randomLongString,
     testCustomAttribute,
@@ -56,6 +59,10 @@ describe('Relationship types form tests', () => {
                         path={`/${section.namePlural}`}
                         customData={{
                             attributes: () => ({ attributes }),
+                            trackedEntityTypes: () => ({
+                                trackedEntityTypes: [],
+                            }),
+                            programs: () => ({ programs: [] }),
                             relationshipTypes: (type: any, params: any) => {
                                 if (type === 'create') {
                                     createMock(params)
@@ -235,6 +242,73 @@ describe('Relationship types form tests', () => {
                 'formfields-toFromName'
             )
             expect(toFromNameField).toBeVisible()
+        })
+
+        it('should open the tracked entity type new form in a drawer when clicking the "Add new" button', async () => {
+            const { screen } = await renderForm()
+
+            await uiActions.clickButtonGroupOption(
+                'from-constraint-field',
+                'TRACKED_ENTITY_INSTANCE',
+                screen
+            )
+
+            await screen.findByTestId('from-tracked-entity-type-selector')
+
+            useSchemaStore.getState().setSchemas({
+                ...useSchemaStore.getState().schemas,
+                trackedEntityType: trackedEntityTypesSchemaMock,
+            } as unknown as ModelSchemas)
+
+            await act(async () => {})
+
+            const tetField = screen.getByTestId(
+                'from-tracked-entity-type-selector'
+            )
+            const addNewButton = within(tetField).getAllByRole('button')[1]
+            await userEvent.click(addNewButton)
+
+            expect(
+                await screen.findByText('Add new Tracked entity type')
+            ).toBeInTheDocument()
+            expect(
+                screen.getByTestId('trackedEntityTypeNewForm')
+            ).toBeInTheDocument()
+            expect(
+                within(
+                    screen.getByTestId('trackedEntityTypeNewForm')
+                ).getByTestId('form-submit-button')
+            ).toHaveTextContent('Save and close')
+        })
+
+        it('should open a new tab when clicking "Add new" for programs instead of opening a drawer', async () => {
+            const { screen } = await renderForm()
+
+            const windowOpenSpy = jest
+                .spyOn(window, 'open')
+                .mockImplementation(() => null)
+
+            await uiActions.clickButtonGroupOption(
+                'from-constraint-field',
+                'PROGRAM_INSTANCE',
+                screen
+            )
+
+            await screen.findByTestId('from-program-selector')
+
+            // Flush the useEffect so LINK_ONLY_SECTIONS check runs and NewItemForm stays undefined
+            await act(async () => {})
+
+            const programField = screen.getByTestId('from-program-selector')
+            const addNewButton = within(programField).getAllByRole('button')[1]
+            await userEvent.click(addNewButton)
+
+            expect(windowOpenSpy).toHaveBeenCalledWith(
+                expect.stringContaining('/programs/new'),
+                '_blank'
+            )
+
+            windowOpenSpy.mockRestore()
         })
     })
 

--- a/src/pages/trackedEntityAttributes/Form.spec.tsx
+++ b/src/pages/trackedEntityAttributes/Form.spec.tsx
@@ -1,9 +1,12 @@
 import { faker } from '@faker-js/faker'
-import { render } from '@testing-library/react'
+import { act, render, within } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
+import optionSetSchemaMock from '../../__mocks__/schema/optionSet.json'
 import schemaMock from '../../__mocks__/schema/trackedEntityAttributes.json'
 import { FOOTER_ID } from '../../app/layout/Layout'
-import { SECTIONS_MAP } from '../../lib'
+import { ModelSchemas, SECTIONS_MAP } from '../../lib'
+import { useSchemaStore } from '../../lib/schemas/schemaStore'
 import {
     randomDhis2Id,
     randomLongString,
@@ -124,6 +127,32 @@ describe('TrackedEntityAttributes form tests', () => {
             await uiAssertions.expectNameToErrorWhenExceedsLength(screen)
             await uiActions.submitForm(screen)
             expect(createMock).not.toHaveBeenCalled()
+        })
+
+        it('should open the option set new form in a drawer when clicking the "Add new" button', async () => {
+            const { screen } = await renderForm()
+
+            useSchemaStore.getState().setSchemas({
+                ...useSchemaStore.getState().schemas,
+                optionSet: optionSetSchemaMock,
+            } as unknown as ModelSchemas)
+
+            await act(async () => {})
+
+            const optionSetField = screen.getByTestId('formfields-optionSet')
+            const addNewButton =
+                within(optionSetField).getAllByRole('button')[1]
+            await userEvent.click(addNewButton)
+
+            expect(
+                await screen.findByText('Add new Option set')
+            ).toBeInTheDocument()
+            expect(screen.getByTestId('optionSetNewForm')).toBeInTheDocument()
+            expect(
+                within(screen.getByTestId('optionSetNewForm')).getByTestId(
+                    'form-submit-button'
+                )
+            ).toHaveTextContent('Save and close')
         })
     })
 

--- a/src/pages/trackedEntityTypes/New.tsx
+++ b/src/pages/trackedEntityTypes/New.tsx
@@ -45,6 +45,7 @@ export const Component = ({
                         <SectionedFormLayout
                             sidebar={<DefaultSectionedFormSidebar />}
                             footer={footer}
+                            dataTest="trackedEntityTypeNewForm"
                         >
                             <form onSubmit={handleSubmit}>
                                 <TrackedEntityTypeFormFields />


### PR DESCRIPTION
Adds additional tests for new forms opening up within drawers on pages using <ModelSingleSelectRefreshableField>. Mainly it checks that the appropriate New.tsx contents is opened in a drawer with a "Save and close" button in the drawer's footer. There is also a test to check that programs do not open in drawer (as we deemed those to be too complex)

I have included one test (with attributes, opening option set) to test that the correct form-within-a-form save is submitted). Adding this to all the tests though requires even more rework and seems a bit like overkill.