### PR TITLE
feat: categories merge with validation [DHIS2-18292]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-06-29T13:37:24.549Z\n"
-"PO-Revision-Date: 2026-06-29T13:37:24.550Z\n"
+"POT-Creation-Date: 2026-07-09T13:25:24.666Z\n"
+"PO-Revision-Date: 2026-07-09T13:25:24.666Z\n"
 
 msgid "schemas"
 msgstr "schemas"
@@ -868,6 +868,15 @@ msgstr "Merging cannot be undone"
 msgid "Confirmation code does not match"
 msgstr "Confirmation code does not match"
 
+msgid "Move data values to the target data element"
+msgstr "Move data values to the target data element"
+
+msgid "Delete the source data values"
+msgstr "Delete the source data values"
+
+msgid "At least one source must be specified to merge"
+msgstr "At least one source must be specified to merge"
+
 msgid "Target must be specified to merge"
 msgstr "Target must be specified to merge"
 
@@ -909,6 +918,9 @@ msgstr "Loading..."
 
 msgid "Add new {{name}}"
 msgstr "Add new {{name}}"
+
+msgid "Saving this {{name}} won't apply unsaved changes in the form below."
+msgstr "Saving this {{name}} won't apply unsaved changes in the form below."
 
 msgid "Available {{name}}"
 msgstr "Available {{name}}"
@@ -2624,6 +2636,15 @@ msgstr "Mandatory: all objects must have a value for this attribute"
 msgid "Unique values only"
 msgstr "Unique values only"
 
+msgid "Configure category merge"
+msgstr "Configure category merge"
+
+msgid "The category merge operation is complete."
+msgstr "The category merge operation is complete."
+
+msgid "All selected categories were merged successfully."
+msgstr "All selected categories were merged successfully."
+
 msgid "Set up the basic information for this category."
 msgstr "Set up the basic information for this category."
 
@@ -2638,6 +2659,45 @@ msgstr "Show as data dimension in analytics apps"
 
 msgid "Choose the options to include in this category."
 msgstr "Choose the options to include in this category."
+
+msgid ""
+"The merge operation will merge the source categories into\n"
+"                the target category. One or many source categories\n"
+"                can be specified"
+msgstr ""
+"The merge operation will merge the source categories into\n"
+"                the target category. One or many source categories\n"
+"                can be specified"
+
+msgid ""
+"Only one target should be specified. The merge operation will\n"
+"                transfer all of the category metadata associations to the\n"
+"                source categories over to the target category."
+msgstr ""
+"Only one target should be specified. The merge operation will\n"
+"                transfer all of the category metadata associations to the\n"
+"                source categories over to the target category."
+
+msgid "Categories to be merged (source)"
+msgstr "Categories to be merged (source)"
+
+msgid "Select categories to merge"
+msgstr "Select categories to merge"
+
+msgid "Category to merge into (target)"
+msgstr "Category to merge into (target)"
+
+msgid "Select category to merge into"
+msgstr "Select category to merge into"
+
+msgid "No categories available. Remove one from source."
+msgstr "No categories available. Remove one from source."
+
+msgid "Merge settings"
+msgstr "Merge settings"
+
+msgid "What should happen to the source categories after the merge is complete?"
+msgstr "What should happen to the source categories after the merge is complete?"
 
 msgid "More than 4 Categories"
 msgstr "More than 4 Categories"
@@ -2801,9 +2861,6 @@ msgstr "Select category option to merge into"
 msgid "No category options available. Remove one from source."
 msgstr "No category options available. Remove one from source."
 
-msgid "Merge settings"
-msgstr "Merge settings"
-
 msgid ""
 "What should happen to the source category options after the merge is "
 "complete?"
@@ -2845,6 +2902,15 @@ msgstr "Set up the information for this data element group."
 
 msgid "Choose the data elements to include in this data element group."
 msgstr "Choose the data elements to include in this data element group."
+
+msgid "Configure data element merge"
+msgstr "Configure data element merge"
+
+msgid "The data element merge operation is complete."
+msgstr "The data element merge operation is complete."
+
+msgid "All selected data elements were merged successfully."
+msgstr "All selected data elements were merged successfully."
 
 msgid "Aggregation level(s)"
 msgstr "Aggregation level(s)"
@@ -2950,6 +3016,54 @@ msgstr ""
 
 msgid "Choose the groups this data element belongs to."
 msgstr "Choose the groups this data element belongs to."
+
+msgid ""
+"The merge operation will merge the source data elements into\n"
+"                the target data element. One or many source data elements\n"
+"                can be specified"
+msgstr ""
+"The merge operation will merge the source data elements into\n"
+"                the target data element. One or many source data elements\n"
+"                can be specified"
+
+msgid ""
+"Only one target should be specified. The merge operation will\n"
+"                transfer all of the data element metadata associations to "
+"the\n"
+"                source data elements over to the target data element."
+msgstr ""
+"Only one target should be specified. The merge operation will\n"
+"                transfer all of the data element metadata associations to "
+"the\n"
+"                source data elements over to the target data element."
+
+msgid "Data elements to be merged (source)"
+msgstr "Data elements to be merged (source)"
+
+msgid "Select data elements to merge"
+msgstr "Select data elements to merge"
+
+msgid "Data element to merge into (target)"
+msgstr "Data element to merge into (target)"
+
+msgid "Select data element to merge into"
+msgstr "Select data element to merge into"
+
+msgid "No data elements available. Remove one from source."
+msgstr "No data elements available. Remove one from source."
+
+msgid "What should happen to the source data elements after the merge is complete?"
+msgstr "What should happen to the source data elements after the merge is complete?"
+
+msgid "What should happen to the data values recorded for the source data elements?"
+msgstr "What should happen to the data values recorded for the source data elements?"
+
+msgid ""
+"Where source and target have the same data value, the most recently updated "
+"is kept."
+msgstr ""
+"Where source and target have the same data value, the most recently updated "
+"is kept."
 
 msgid "Error"
 msgstr "Error"

--- a/src/components/merge/DefaultMergeFormContents.tsx
+++ b/src/components/merge/DefaultMergeFormContents.tsx
@@ -58,6 +58,29 @@ export const DefaultMergeFormContents = (
     )
 }
 
+const getTooltipContent = ({
+    failsExtraValidation,
+    extraValidationString,
+    sourcesEmpty,
+    targetInputEmpty,
+}: {
+    failsExtraValidation: boolean
+    extraValidationString: string | undefined
+    sourcesEmpty: boolean
+    targetInputEmpty: boolean
+}) => {
+    if (failsExtraValidation) {
+        return extraValidationString
+    }
+    if (sourcesEmpty) {
+        return i18n.t('At least one source must be specified to merge')
+    }
+    if (targetInputEmpty) {
+        return i18n.t('Target must be specified to merge')
+    }
+    return i18n.t('Correct confirmation code must be entered to merge')
+}
+
 const TooltipWrapper = ({
     children,
     codeConfirmInvalid,
@@ -79,13 +102,12 @@ const TooltipWrapper = ({
     ) {
         return children
     }
-    const content = failsExtraValidation
-        ? extraValidationString
-        : sourcesEmpty
-        ? i18n.t('At least one source must be specified to merge')
-        : targetInputEmpty
-        ? i18n.t('Target must be specified to merge')
-        : i18n.t('Correct confirmation code must be entered to merge')
+    const content = getTooltipContent({
+        failsExtraValidation,
+        extraValidationString,
+        sourcesEmpty,
+        targetInputEmpty,
+    })
 
     return <Tooltip content={content}>{children}</Tooltip>
 }

--- a/src/components/merge/DefaultMergeFormContents.tsx
+++ b/src/components/merge/DefaultMergeFormContents.tsx
@@ -1,6 +1,6 @@
 import i18n from '@dhis2/d2-i18n'
 import { Button, ButtonStrip, CircularLoader, Tooltip } from '@dhis2/ui'
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useField, useFormState } from 'react-final-form'
 import { useModelSectionHandleOrThrow } from '../../lib'
 import { ModelSection } from '../../types'
@@ -10,11 +10,17 @@ import { StandardFormSectionTitle } from '../standardForm'
 import css from './MergeForm.module.css'
 import { MergeFormValuesBase } from './mergeSchemaBase'
 
+type ExtraValidationFunction = (values: {
+    target: string
+    sources: string[]
+}) => string | undefined
+
 export const DefaultMergeFormContents = (
     props: React.PropsWithChildren<{
         title?: React.ReactNode
         mergeCompleteElement?: React.ReactElement
         mergeInProgressElement?: React.ReactElement
+        extraValidation?: ExtraValidationFunction
     }>
 ) => {
     const { children, title, mergeCompleteElement, mergeInProgressElement } =
@@ -47,7 +53,7 @@ export const DefaultMergeFormContents = (
             {title}
             {children}
             <DefaultFormErrorNotice />
-            <MergeActions />
+            <MergeActions extraValidation={props.extraValidation} />
         </>
     )
 }
@@ -57,15 +63,25 @@ const TooltipWrapper = ({
     codeConfirmInvalid,
     targetInputEmpty,
     sourcesEmpty,
+    extraValidationString,
 }: React.PropsWithChildren<{
     codeConfirmInvalid: boolean
     targetInputEmpty: boolean
     sourcesEmpty: boolean
+    extraValidationString: string | undefined
 }>) => {
-    if (!codeConfirmInvalid && !targetInputEmpty && !sourcesEmpty) {
+    const failsExtraValidation = Boolean(extraValidationString)
+    if (
+        !codeConfirmInvalid &&
+        !targetInputEmpty &&
+        !sourcesEmpty &&
+        !failsExtraValidation
+    ) {
         return children
     }
-    const content = sourcesEmpty
+    const content = failsExtraValidation
+        ? extraValidationString
+        : sourcesEmpty
         ? i18n.t('At least one source must be specified to merge')
         : targetInputEmpty
         ? i18n.t('Target must be specified to merge')
@@ -74,10 +90,26 @@ const TooltipWrapper = ({
     return <Tooltip content={content}>{children}</Tooltip>
 }
 
-export const MergeActions = () => {
+export const MergeActions = ({
+    extraValidation,
+}: {
+    extraValidation?: ExtraValidationFunction
+}) => {
     const codeConfirmInvalid = useField<string[]>('confirmation').meta?.invalid
-    const targetInputEmpty = !useField<string[]>('target').input?.value
-    const sourcesEmpty = !useField<string[]>('sources').input?.value?.length
+    const targetInput = useField<{ id: string }>('target').input?.value
+    const sourcesInputs = useField<{ id: string }[]>('sources').input?.value
+    const targetInputEmpty = !useField<{ id: string }>('target').input?.value
+    const sourcesEmpty =
+        !useField<{ id: string }[]>('sources').input?.value?.length
+    // validate extra validation if provided and source and target are not empty
+    const extraValidationString = useMemo(() => {
+        return extraValidation && !targetInputEmpty && !sourcesEmpty
+            ? extraValidation({
+                  target: targetInput?.id,
+                  sources: sourcesInputs?.map((option) => option.id),
+              })
+            : undefined
+    }, [extraValidation, targetInput, sourcesInputs])
 
     return (
         <ButtonStrip className={css.mergeActions}>
@@ -85,12 +117,16 @@ export const MergeActions = () => {
                 codeConfirmInvalid={codeConfirmInvalid ?? false}
                 targetInputEmpty={targetInputEmpty}
                 sourcesEmpty={sourcesEmpty}
+                extraValidationString={extraValidationString}
             >
                 <Button
                     primary
                     type="submit"
                     disabled={
-                        sourcesEmpty || targetInputEmpty || codeConfirmInvalid
+                        sourcesEmpty ||
+                        targetInputEmpty ||
+                        codeConfirmInvalid ||
+                        Boolean(extraValidationString?.length)
                     }
                 >
                     {i18n.t('Merge')}

--- a/src/lib/sections/mergableSections.ts
+++ b/src/lib/sections/mergableSections.ts
@@ -7,6 +7,7 @@ const sectionAuthorityMap = new Map<ModelSection, string>([
     [SECTIONS_MAP.indicator, 'F_INDICATOR_MERGE'],
     [SECTIONS_MAP.indicatorType, 'F_INDICATOR_TYPE_MERGE'],
     [SECTIONS_MAP.categoryOption, 'F_CATEGORY_OPTION_MERGE'],
+    [SECTIONS_MAP.category, 'F_CATEGORY_MERGE'],
     [SECTIONS_MAP.dataElement, 'F_DATA_ELEMENT_MERGE'],
 ])
 

--- a/src/pages/categories/Merge.spec.tsx
+++ b/src/pages/categories/Merge.spec.tsx
@@ -1,0 +1,37 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { SECTIONS_MAP } from '../../lib'
+import { testCategory } from '../../testUtils/builders'
+import TestComponentWithRouter, {
+    CustomData,
+} from '../../testUtils/TestComponentWithRouter'
+import { generateDefaultMergeTests } from '../defaultMergeTests'
+import { Component as Merge } from './Merge'
+
+const renderMerge = async (customData: CustomData = {}) => {
+    const routeOptions = {
+        handle: { section: SECTIONS_MAP.category },
+    }
+
+    return render(
+        <TestComponentWithRouter
+            path="/categories/merge"
+            customData={{
+                categories: {
+                    categories: [testCategory(), testCategory()],
+                    pager: { page: 1, pageCount: 1, total: 2, pageSize: 10 },
+                },
+                ...customData,
+            }}
+            routeOptions={routeOptions}
+        >
+            <Merge />
+        </TestComponentWithRouter>
+    )
+}
+
+generateDefaultMergeTests({
+    componentName: 'Category',
+    mergeResource: 'categories/merge',
+    renderMerge,
+})

--- a/src/pages/categories/Merge.spec.tsx
+++ b/src/pages/categories/Merge.spec.tsx
@@ -1,17 +1,29 @@
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import { userEvent } from '@testing-library/user-event'
 import React from 'react'
 import { SECTIONS_MAP } from '../../lib'
 import { testCategory } from '../../testUtils/builders'
 import TestComponentWithRouter, {
     CustomData,
 } from '../../testUtils/TestComponentWithRouter'
-import { generateDefaultMergeTests } from '../defaultMergeTests'
+import {
+    generateDefaultMergeTests,
+    getMergeButton,
+    pickFirstSource,
+    pickTarget,
+} from '../defaultMergeTests'
 import { Component as Merge } from './Merge'
 
-const renderMerge = async (customData: CustomData = {}) => {
+const renderMerge = async (
+    customData: CustomData = {},
+    selectedModels?: Set<string>
+) => {
     const routeOptions = {
         handle: { section: SECTIONS_MAP.category },
     }
+    const initialEntry = selectedModels
+        ? { pathname: '/categories/merge', state: { selectedModels } }
+        : '/categories/merge'
 
     return render(
         <TestComponentWithRouter
@@ -24,6 +36,8 @@ const renderMerge = async (customData: CustomData = {}) => {
                 ...customData,
             }}
             routeOptions={routeOptions}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            initialEntries={[initialEntry] as any}
         >
             <Merge />
         </TestComponentWithRouter>
@@ -34,4 +48,110 @@ generateDefaultMergeTests({
     componentName: 'Category',
     mergeResource: 'categories/merge',
     renderMerge,
+})
+
+describe('data element merge additional tests', () => {
+    it('disables merge button and hides ConfirmationField when source and target have different category options', async () => {
+        const cat1 = testCategory({
+            categoryOptions: [{ id: 'co-1' }],
+            categoryCombo: { id: 'combo-1' },
+        })
+        const cat2 = testCategory({
+            categoryOptions: [{ id: 'co-2' }],
+            categoryCombo: { id: 'combo-1' },
+        })
+
+        const screen = await renderMerge(
+            {
+                categories: {
+                    categories: [cat1, cat2],
+                    pager: { page: 1, pageCount: 1, total: 2, pageSize: 10 },
+                },
+            },
+            new Set([cat1.id, cat2.id])
+        )
+
+        await pickFirstSource(screen)
+        await pickTarget(screen)
+
+        await waitFor(() => expect(getMergeButton(screen)).toBeDisabled())
+        await userEvent.hover(getMergeButton(screen))
+        expect(
+            await screen.findByText(
+                'Category options of source and target categories do not match'
+            )
+        ).toBeInTheDocument()
+        await waitFor(() =>
+            expect(
+                screen.queryByText(/merging cannot be undone/i)
+            ).not.toBeInTheDocument()
+        )
+    })
+    it('disables merge button and hides ConfirmationField when source and target have different category combos', async () => {
+        const cat1 = testCategory({
+            categoryOptions: [{ id: 'co-1' }],
+            categoryCombo: { id: 'combo-1' },
+        })
+        const cat2 = testCategory({
+            categoryOptions: [{ id: 'co-1' }],
+            categoryCombo: { id: 'combo-2' },
+        })
+
+        const screen = await renderMerge(
+            {
+                categories: {
+                    categories: [cat1, cat2],
+                    pager: { page: 1, pageCount: 1, total: 2, pageSize: 10 },
+                },
+            },
+            new Set([cat1.id, cat2.id])
+        )
+
+        await pickFirstSource(screen)
+        await pickTarget(screen)
+
+        await waitFor(() => expect(getMergeButton(screen)).toBeDisabled())
+        await userEvent.hover(getMergeButton(screen))
+        expect(
+            await screen.findByText(
+                'Category combos of source and target categories do not match'
+            )
+        ).toBeInTheDocument()
+        await waitFor(() =>
+            expect(
+                screen.queryByText(/merging cannot be undone/i)
+            ).not.toBeInTheDocument()
+        )
+    })
+    it('prompts for confirmation when source and target have matching category options and category combos', async () => {
+        const cat1 = testCategory({
+            categoryOptions: [{ id: 'co-1' }],
+            categoryCombo: { id: 'combo-1' },
+        })
+        const cat2 = testCategory({
+            categoryOptions: [{ id: 'co-1' }],
+            categoryCombo: { id: 'combo-1' },
+        })
+
+        const screen = await renderMerge(
+            {
+                categories: {
+                    categories: [cat1, cat2],
+                    pager: { page: 1, pageCount: 1, total: 2, pageSize: 10 },
+                },
+            },
+            new Set([cat1.id, cat2.id])
+        )
+
+        await pickFirstSource(screen)
+        await pickTarget(screen)
+
+        await waitFor(() => expect(getMergeButton(screen)).toBeDisabled())
+
+        await waitFor(() =>
+            expect(
+                screen.queryByText(/merging cannot be undone/i)
+            ).toBeInTheDocument()
+        )
+    })
 })

--- a/src/pages/categories/Merge.spec.tsx
+++ b/src/pages/categories/Merge.spec.tsx
@@ -54,11 +54,11 @@ describe('data element merge additional tests', () => {
     it('disables merge button and hides ConfirmationField when source and target have different category options', async () => {
         const cat1 = testCategory({
             categoryOptions: [{ id: 'co-1' }],
-            categoryCombo: { id: 'combo-1' },
+            categoryCombos: [{ id: 'combo-1' }],
         })
         const cat2 = testCategory({
             categoryOptions: [{ id: 'co-2' }],
-            categoryCombo: { id: 'combo-1' },
+            categoryCombos: [{ id: 'combo-2' }],
         })
 
         const screen = await renderMerge(
@@ -87,14 +87,14 @@ describe('data element merge additional tests', () => {
             ).not.toBeInTheDocument()
         )
     })
-    it('disables merge button and hides ConfirmationField when source and target have different category combos', async () => {
+    it('disables merge button and hides ConfirmationField when source and target have overlapping category combos', async () => {
         const cat1 = testCategory({
             categoryOptions: [{ id: 'co-1' }],
-            categoryCombo: { id: 'combo-1' },
+            categoryCombos: [{ id: 'combo-1' }],
         })
         const cat2 = testCategory({
             categoryOptions: [{ id: 'co-1' }],
-            categoryCombo: { id: 'combo-2' },
+            categoryCombos: [{ id: 'combo-1' }],
         })
 
         const screen = await renderMerge(
@@ -114,7 +114,7 @@ describe('data element merge additional tests', () => {
         await userEvent.hover(getMergeButton(screen))
         expect(
             await screen.findByText(
-                'Category combos of source and target categories do not match'
+                'Categories must have unique, non-overlapping category combos'
             )
         ).toBeInTheDocument()
         await waitFor(() =>
@@ -126,11 +126,42 @@ describe('data element merge additional tests', () => {
     it('prompts for confirmation when source and target have matching category options and category combos', async () => {
         const cat1 = testCategory({
             categoryOptions: [{ id: 'co-1' }],
-            categoryCombo: { id: 'combo-1' },
+            categoryCombos: [{ id: 'combo-1' }],
         })
         const cat2 = testCategory({
             categoryOptions: [{ id: 'co-1' }],
-            categoryCombo: { id: 'combo-1' },
+            categoryCombos: [{ id: 'combo-2' }],
+        })
+
+        const screen = await renderMerge(
+            {
+                categories: {
+                    categories: [cat1, cat2],
+                    pager: { page: 1, pageCount: 1, total: 2, pageSize: 10 },
+                },
+            },
+            new Set([cat1.id, cat2.id])
+        )
+
+        await pickFirstSource(screen)
+        await pickTarget(screen)
+
+        await waitFor(() => expect(getMergeButton(screen)).toBeDisabled())
+
+        await waitFor(() =>
+            expect(
+                screen.queryByText(/merging cannot be undone/i)
+            ).toBeInTheDocument()
+        )
+    })
+    it('prompts for confirmation when source and target have matching category options and some categories are missing category combos', async () => {
+        const cat1 = testCategory({
+            categoryOptions: [{ id: 'co-1' }],
+            categoryCombos: [],
+        })
+        const cat2 = testCategory({
+            categoryOptions: [{ id: 'co-1' }],
+            categoryCombos: [{ id: 'combo-2' }],
         })
 
         const screen = await renderMerge(

--- a/src/pages/categories/Merge.tsx
+++ b/src/pages/categories/Merge.tsx
@@ -1,0 +1,90 @@
+import { useDataEngine } from '@dhis2/app-runtime'
+import i18n from '@dhis2/d2-i18n'
+import React, { useMemo } from 'react'
+import { Form } from 'react-final-form'
+import {
+    DefaultMergeFormContents,
+    MergeComplete,
+    StyledMergeForm,
+    Title,
+} from '../../components/merge'
+import { getDefaultsOld, useLocationWithState } from '../../lib'
+import { createFormError } from '../../lib/form/createFormError'
+import { CategoryMergeFormFields } from './merge/CategoryMergeFormFields'
+import {
+    CategoryMergeFormValues,
+    mergeFormSchema,
+    validate,
+} from './merge/CategoryMergeSchema'
+
+export const Component = () => {
+    const location = useLocationWithState<{ selectedModels: Set<string> }>()
+
+    const dataEngine = useDataEngine()
+    const selectedIds: string[] = useMemo(
+        () => Array.from(location.state?.selectedModels ?? []),
+        [location.state?.selectedModels]
+    )
+    const initialValues = useMemo(
+        () => ({
+            ...getDefaultsOld(mergeFormSchema),
+            target: undefined,
+            sources: [],
+        }),
+        []
+    )
+
+    const onSubmit = async (values: CategoryMergeFormValues) => {
+        try {
+            const data = mergeFormSchema.parse(values)
+            await dataEngine.mutate({
+                resource: 'categories/merge',
+                type: 'create',
+                data,
+            })
+            return undefined
+        } catch (e) {
+            console.error(e)
+            return createFormError(e)
+        }
+    }
+
+    return (
+        <Form
+            initialValues={initialValues}
+            onSubmit={onSubmit}
+            validate={validate}
+            subscription={{
+                values: false,
+                submitting: true,
+                submitSucceeded: true,
+            }}
+        >
+            {({ handleSubmit }) => (
+                <StyledMergeForm onSubmit={handleSubmit}>
+                    <DefaultMergeFormContents
+                        title={
+                            <Title>{i18n.t('Configure category merge')}</Title>
+                        }
+                        mergeCompleteElement={
+                            <MergeComplete>
+                                <p>
+                                    {i18n.t(
+                                        'The category merge operation is complete.'
+                                    )}
+                                </p>
+                                <p>
+                                    {i18n.t(
+                                        'All selected categories were merged successfully.'
+                                    )}
+                                </p>
+                            </MergeComplete>
+                        }
+                    >
+                        <CategoryMergeFormFields selectedIds={selectedIds} />
+                    </DefaultMergeFormContents>
+                </StyledMergeForm>
+            )}
+        </Form>
+    )
+}

--- a/src/pages/categories/Merge.tsx
+++ b/src/pages/categories/Merge.tsx
@@ -1,6 +1,7 @@
 import { useDataEngine } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
-import React, { useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import React, { useCallback, useMemo, useState } from 'react'
 import { Form } from 'react-final-form'
 import {
     DefaultMergeFormContents,
@@ -8,7 +9,11 @@ import {
     StyledMergeForm,
     Title,
 } from '../../components/merge'
-import { getDefaultsOld, useLocationWithState } from '../../lib'
+import {
+    getDefaultsOld,
+    useLocationWithState,
+    useBoundResourceQueryFn,
+} from '../../lib'
 import { createFormError } from '../../lib/form/createFormError'
 import { CategoryMergeFormFields } from './merge/CategoryMergeFormFields'
 import {
@@ -17,7 +22,45 @@ import {
     validate,
 } from './merge/CategoryMergeSchema'
 
+type CategoryDetails = {
+    id: string
+    categoryCombo: { id: string }
+    categoryOptions: { id: string }[]
+}
+type CategoriesDetailsResponse = { categories: CategoryDetails[] }
+
+export const useCategoriesDetailsQuery = ({
+    selectedIdsString,
+}: {
+    selectedIdsString: string
+}) => {
+    const queryFn = useBoundResourceQueryFn()
+
+    return useQuery({
+        queryKey: [
+            {
+                resource: 'categories',
+                params: {
+                    fields: ['id', 'categoryCombo[id]', 'categoryOptions[id]'],
+                    filter: [`id:in:[${selectedIdsString}]`],
+                    paging: false,
+                },
+            },
+        ],
+        enabled: !!selectedIdsString,
+        queryFn: queryFn<CategoriesDetailsResponse>,
+        select: useCallback((data: CategoriesDetailsResponse) => {
+            return data.categories.reduce((acc, category) => {
+                acc[category.id] = category
+                return acc
+            }, {} as Record<string, CategoryDetails>)
+        }, []),
+    })
+}
+
 export const Component = () => {
+    const [extraValidationResult, setExtraValidationResult] =
+        useState<boolean>(true)
     const location = useLocationWithState<{ selectedModels: Set<string> }>()
 
     const dataEngine = useDataEngine()
@@ -32,6 +75,56 @@ export const Component = () => {
             sources: [],
         }),
         []
+    )
+
+    const { data: categoryDetails } = useCategoriesDetailsQuery({
+        selectedIdsString: selectedIds.join(','),
+    })
+
+    const extraValidate: (values: {
+        target: string
+        sources: string[]
+    }) => string | undefined = useCallback(
+        (values) => {
+            if (!values.target || !values.sources || !categoryDetails) {
+                return undefined
+            }
+            // keep target as poin of reference
+            const targetCategory = categoryDetails[values.target]
+            const targetCategoryOptions = targetCategory.categoryOptions
+                .map((co) => co.id)
+                .sort()
+                .join(',')
+            for (const category of values.sources) {
+                const sourceCategory = categoryDetails[category]
+                const sourceCategoryOptions = sourceCategory.categoryOptions
+                    .map((co) => co.id)
+                    .sort()
+                    .join(',')
+
+                // if category options are not the same
+                if (sourceCategoryOptions !== targetCategoryOptions) {
+                    setExtraValidationResult(false)
+                    return i18n.t(
+                        'Category options of source and target categories do not match'
+                    )
+                }
+                // if category combos are not the same
+                if (
+                    sourceCategory.categoryCombo.id !==
+                    targetCategory.categoryCombo.id
+                ) {
+                    setExtraValidationResult(false)
+                    return i18n.t(
+                        'Category combos of source and target categories do not match'
+                    )
+                }
+            }
+            // if category combo of any items do not match
+            setExtraValidationResult(true)
+            return undefined
+        },
+        [categoryDetails, setExtraValidationResult]
     )
 
     const onSubmit = async (values: CategoryMergeFormValues) => {
@@ -80,8 +173,12 @@ export const Component = () => {
                                 </p>
                             </MergeComplete>
                         }
+                        extraValidation={extraValidate}
                     >
-                        <CategoryMergeFormFields selectedIds={selectedIds} />
+                        <CategoryMergeFormFields
+                            selectedIds={selectedIds}
+                            hideConfirmation={!extraValidationResult}
+                        />
                     </DefaultMergeFormContents>
                 </StyledMergeForm>
             )}

--- a/src/pages/categories/Merge.tsx
+++ b/src/pages/categories/Merge.tsx
@@ -24,7 +24,7 @@ import {
 
 type CategoryDetails = {
     id: string
-    categoryCombo: { id: string }
+    categoryCombos: { id: string }[]
     categoryOptions: { id: string }[]
 }
 type CategoriesDetailsResponse = { categories: CategoryDetails[] }
@@ -41,7 +41,7 @@ export const useCategoriesDetailsQuery = ({
             {
                 resource: 'categories',
                 params: {
-                    fields: ['id', 'categoryCombo[id]', 'categoryOptions[id]'],
+                    fields: ['id', 'categoryCombos[id]', 'categoryOptions[id]'],
                     filter: [`id:in:[${selectedIdsString}]`],
                     paging: false,
                 },
@@ -89,12 +89,20 @@ export const Component = () => {
             if (!values.target || !values.sources || !categoryDetails) {
                 return undefined
             }
-            // keep target as poin of reference
+            // keep target as point of reference
             const targetCategory = categoryDetails[values.target]
             const targetCategoryOptions = targetCategory.categoryOptions
                 .map((co) => co.id)
                 .sort()
                 .join(',')
+            const allCategoryCombosSet = targetCategory.categoryCombos.reduce(
+                (acc, cc) => {
+                    acc.add(cc.id)
+                    return acc
+                },
+                new Set<string>()
+            )
+            let overlap = false
             for (const category of values.sources) {
                 const sourceCategory = categoryDetails[category]
                 const sourceCategoryOptions = sourceCategory.categoryOptions
@@ -109,18 +117,23 @@ export const Component = () => {
                         'Category options of source and target categories do not match'
                     )
                 }
-                // if category combos are not the same
-                if (
-                    sourceCategory.categoryCombo.id !==
-                    targetCategory.categoryCombo.id
-                ) {
+                // check for overlap in category combos
+                for (const sourceCategoryCombo of sourceCategory.categoryCombos) {
+                    if (allCategoryCombosSet.has(sourceCategoryCombo.id)) {
+                        overlap = true
+                        break
+                    } else {
+                        allCategoryCombosSet.add(sourceCategoryCombo.id)
+                    }
+                }
+                if (overlap) {
                     setExtraValidationResult(false)
                     return i18n.t(
-                        'Category combos of source and target categories do not match'
+                        'Categories must have unique, non-overlapping category combos'
                     )
                 }
             }
-            // if category combo of any items do not match
+
             setExtraValidationResult(true)
             return undefined
         },

--- a/src/pages/categories/form/categorySchema.ts
+++ b/src/pages/categories/form/categorySchema.ts
@@ -29,6 +29,7 @@ export const categoryFormSchema = identifiable
 export const categoryListSchema = categoryBaseSchema
     .merge(withDefaultListColumns)
     .extend({
+        name: z.string(),
         displayShortName: z.string(),
     })
 

--- a/src/pages/categories/merge/CategoryMergeFormFields.tsx
+++ b/src/pages/categories/merge/CategoryMergeFormFields.tsx
@@ -14,8 +14,10 @@ import {
 
 export const CategoryMergeFormFields = ({
     selectedIds,
+    hideConfirmation = false,
 }: {
     selectedIds: string[]
+    hideConfirmation?: boolean
 }) => {
     return (
         <FormSections>
@@ -82,7 +84,7 @@ export const CategoryMergeFormFields = ({
                 />
             </FormSection>
             <FormSection>
-                <ConfirmationField />
+                {!hideConfirmation && <ConfirmationField />}
             </FormSection>
         </FormSections>
     )

--- a/src/pages/categories/merge/CategoryMergeFormFields.tsx
+++ b/src/pages/categories/merge/CategoryMergeFormFields.tsx
@@ -1,0 +1,89 @@
+import i18n from '@dhis2/d2-i18n'
+import React from 'react'
+import { StandardFormSectionTitle } from '../../../components'
+import {
+    BaseSourcesField,
+    BaseTargetField,
+    MergeSourcesTargetWrapper,
+    DeleteSourcesFields,
+    Description,
+    FormSection,
+    FormSections,
+    ConfirmationField,
+} from '../../../components/merge'
+
+export const CategoryMergeFormFields = ({
+    selectedIds,
+}: {
+    selectedIds: string[]
+}) => {
+    return (
+        <FormSections>
+            <FormSection>
+                <Description>
+                    <p>
+                        {i18n.t(`The merge operation will merge the source categories into
+                the target category. One or many source categories
+                can be specified`)}
+                    </p>
+                    <p>
+                        {i18n.t(`Only one target should be specified. The merge operation will
+                transfer all of the category metadata associations to the
+                source categories over to the target category.`)}
+                    </p>
+                </Description>
+                <MergeSourcesTargetWrapper>
+                    <BaseSourcesField
+                        label={i18n.t('Categories to be merged (source)')}
+                        placeholder={i18n.t('Select categories to merge')}
+                        query={{
+                            resource: 'categories',
+                            params: {
+                                fields: ['id', 'displayName', 'name'],
+                                filter: `id:in:[${selectedIds.join(',')}]`,
+                            },
+                        }}
+                    />
+                    <BaseTargetField
+                        label={i18n.t('Category to merge into (target)')}
+                        placeholder={i18n.t('Select category to merge into')}
+                        query={{
+                            resource: 'categories',
+                            params: {
+                                fields: ['id', 'displayName', 'name'],
+                                filter: `id:in:[${selectedIds.join(',')}]`,
+                            },
+                        }}
+                        noMatchWithoutFilterText={i18n.t(
+                            'No categories available. Remove one from source.'
+                        )}
+                    />
+                </MergeSourcesTargetWrapper>
+            </FormSection>
+            <FormSection>
+                <StandardFormSectionTitle>
+                    {i18n.t('Merge settings')}
+                </StandardFormSectionTitle>
+
+                <DeleteSourcesFields
+                    groupLabel={i18n.t(
+                        'What should happen to the source categories after the merge is complete?'
+                    )}
+                    getKeepLabel={(count) =>
+                        i18n.t('Keep {{ count }} source categories', {
+                            count,
+                        })
+                    }
+                    getDeleteLabel={(count) =>
+                        i18n.t('Delete {{ count }} source categories', {
+                            count,
+                        })
+                    }
+                />
+            </FormSection>
+            <FormSection>
+                <ConfirmationField />
+            </FormSection>
+        </FormSections>
+    )
+}

--- a/src/pages/categories/merge/CategoryMergeSchema.ts
+++ b/src/pages/categories/merge/CategoryMergeSchema.ts
@@ -1,0 +1,31 @@
+import i18n from '@dhis2/d2-i18n'
+import { z } from 'zod'
+import { mergeFormSchemaBase } from '../../../components/merge'
+import { createFormValidate } from '../../../lib'
+
+const categorySchema = z.object({
+    id: z.string(),
+    displayName: z.string(),
+    name: z.string(),
+})
+
+export const mergeFormSchema = mergeFormSchemaBase
+    .extend({
+        sources: z
+            .array(categorySchema)
+            .min(1, i18n.t('At least one source is required'))
+            .default([]),
+        target: categorySchema,
+        dataMergeStrategy: z
+            .enum(['LAST_UPDATED', 'DISCARD'])
+            .default('LAST_UPDATED'),
+    })
+    .transform((data) => ({
+        ...data,
+        sources: data.sources.map((source) => source.id),
+        target: data.target.id,
+    }))
+
+export type CategoryMergeFormValues = z.input<typeof mergeFormSchema>
+
+export const validate = createFormValidate(mergeFormSchema)

--- a/src/pages/categories/merge/index.ts
+++ b/src/pages/categories/merge/index.ts
@@ -1,0 +1,2 @@
+export * from './CategoryMergeFormFields'
+export * from './CategoryMergeSchema'

--- a/src/pages/defaultMergeTests.tsx
+++ b/src/pages/defaultMergeTests.tsx
@@ -9,7 +9,7 @@ const getSourcesField = (screen: RenderResult) =>
     screen.getByTestId(SOURCES_TEST_ID)
 const getTargetField = (screen: RenderResult) =>
     screen.getByTestId(TARGET_TEST_ID)
-const getMergeButton = (screen: RenderResult) =>
+export const getMergeButton = (screen: RenderResult) =>
     screen.getByRole('button', { name: 'Merge' })
 
 const openSelect = async (container: HTMLElement, screen: RenderResult) => {
@@ -26,7 +26,7 @@ const closeSelect = async (container: HTMLElement) => {
 }
 
 // picks the first available source, returns its displayed label
-const pickFirstSource = async (screen: RenderResult) => {
+export const pickFirstSource = async (screen: RenderResult) => {
     const sourcesField = getSourcesField(screen)
     const menu = await openSelect(sourcesField, screen)
     const option = (
@@ -40,7 +40,7 @@ const pickFirstSource = async (screen: RenderResult) => {
 
 // picks the first available target, returns its displayed label
 // (single-select closes itself on selection, unlike multi-select)
-const pickTarget = async (screen: RenderResult) => {
+export const pickTarget = async (screen: RenderResult) => {
     const targetField = getTargetField(screen)
     const menu = await openSelect(targetField, screen)
     const option = (


### PR DESCRIPTION
See: https://dhis2.atlassian.net/browse/DHIS2-18292.

In addition to standard merge form, the categories merge is restricted to cases where:


> 1. [Categories] have identical category options
> 2. source and target categories do not share category combos
> 3. source categories do not share category combos with each other

Hence, it was necessary to add an extra validation and disable merge button when these conditions were not met. I started by passing a validator function down to the DefaultMergeContents from the Merge.tsx file as I thought this would be most reusable. However, I then realised that the confirmation box checks the logic independently, so then I also needed to keep the results of the validation in state in Merge.tsx. This ends up being a little more muddled than I'd like. We could just do the validation at the highest level of the form and pass the resulting validation string down to DefaultMergeContents instead of a validator function, but then the choice of where to do the validation in the form is kind of random, so I just kept it in DefaultMergeContents. I'm happy to revisit now, or to revisit when we do some more code clean up refactoring (at which point, maybe we'd consider consolidating the logic checks that also are used for <ConfirmationField>.