### PR TITLE
fix: filter variables for events expression builder [DHIS2-21494]

### DIFF
--- a/src/components/ExpressionBuilder/ExpressionBuilder.tsx
+++ b/src/components/ExpressionBuilder/ExpressionBuilder.tsx
@@ -86,6 +86,7 @@ export const ExpressionBuilder = ({
     title,
     initialValue,
     programId,
+    programType,
     type,
     clearable,
     clearExpression,
@@ -96,6 +97,7 @@ export const ExpressionBuilder = ({
     title: string
     initialValue: string
     programId?: string
+    programType?: string
     type: ExpressionBuilderType
     clearable: boolean
     clearExpression?: () => void
@@ -210,6 +212,7 @@ export const ExpressionBuilder = ({
                             elementRef={expressionRef}
                             clearValidationState={clearValidationState}
                             programId={programId}
+                            programType={programType}
                             type={type}
                         />
                     </div>

--- a/src/components/ExpressionBuilder/ExpressionBuilderEntry.tsx
+++ b/src/components/ExpressionBuilder/ExpressionBuilderEntry.tsx
@@ -23,6 +23,7 @@ type ExpressionBuilderEntryProps = Readonly<{
     validateProperty?: string
     clearable?: boolean
     programId?: string
+    programType?: string
     type?: ExpressionBuilderType
     disabled?: boolean
 }>
@@ -38,6 +39,7 @@ export const ExpressionBuilderEntry = ({
     validateProperty,
     clearable = false,
     programId,
+    programType,
     type = 'default',
     disabled = false,
 }: ExpressionBuilderEntryProps) => {
@@ -137,6 +139,7 @@ export const ExpressionBuilderEntry = ({
                     fieldName={fieldName}
                     validationResource={validationResource}
                     programId={programId}
+                    programType={programType}
                     type={type}
                     clearable={clearable}
                     clearExpression={clearExpression}

--- a/src/components/ExpressionBuilder/ValidationRuleVariables.tsx
+++ b/src/components/ExpressionBuilder/ValidationRuleVariables.tsx
@@ -807,6 +807,38 @@ const PROGRAM_RULE_VARIABLE_ELEMENTS: Element[] = PROGRAM_RULE_VARIABLE_IDS.map(
     (id) => ({ id, displayName: id })
 )
 
+const ENROLLMENT_ONLY_VARIABLE_IDS = new Set([
+    'V{enrollment_date}',
+    'V{enrollment_status}',
+    'V{incident_date}',
+])
+
+const filterEnrollmentVariables = (
+    elements: Element[],
+    isEventProgram: boolean
+) =>
+    isEventProgram
+        ? elements.filter(
+              (element) => !ENROLLMENT_ONLY_VARIABLE_IDS.has(element.id)
+          )
+        : elements
+
+const withFilteredVariables = (
+    elementTypes: ElementType[],
+    isEventProgram: boolean
+): ElementType[] =>
+    elementTypes.map((elementType) =>
+        elementType.type === 'variables'
+            ? {
+                  ...elementType,
+                  elements: filterEnrollmentVariables(
+                      elementType.elements ?? [],
+                      isEventProgram
+                  ),
+              }
+            : elementType
+    )
+
 const PROGRAM_RULE_FUNCTION_ELEMENTS = [
     { id: 'd2:ceil( <number> )', displayName: 'd2:ceil( <number> )' },
     { id: 'd2:floor( <number> )', displayName: 'd2:floor( <number> )' },
@@ -1017,15 +1049,23 @@ programIndicatorElementTypesCount[1] = {
 
 export const getElementTypes = (
     type: ExpressionBuilderType,
-    { aggregationType }: { aggregationType: string | undefined }
+    {
+        aggregationType,
+        isEventProgram = false,
+    }: {
+        aggregationType: string | undefined
+        isEventProgram?: boolean
+    }
 ): ElementType[] => {
     if (type === 'programIndicator') {
-        return aggregationType === 'COUNT'
-            ? programIndicatorElementTypesCount
-            : programIndicatorElementTypes
+        const elementTypes =
+            aggregationType === 'COUNT'
+                ? programIndicatorElementTypesCount
+                : programIndicatorElementTypes
+        return withFilteredVariables(elementTypes, isEventProgram)
     }
     if (type === 'programRule') {
-        return programRuleElementTypes
+        return withFilteredVariables(programRuleElementTypes, isEventProgram)
     }
     if (type === 'indicator') {
         return indicatorElementTypes

--- a/src/components/ExpressionBuilder/ValidationRuleVariables.tsx
+++ b/src/components/ExpressionBuilder/ValidationRuleVariables.tsx
@@ -823,22 +823,6 @@ const filterEnrollmentVariables = (
           )
         : elements
 
-const withFilteredVariables = (
-    elementTypes: ElementType[],
-    isEventProgram: boolean
-): ElementType[] =>
-    elementTypes.map((elementType) =>
-        elementType.type === 'variables'
-            ? {
-                  ...elementType,
-                  elements: filterEnrollmentVariables(
-                      elementType.elements ?? [],
-                      isEventProgram
-                  ),
-              }
-            : elementType
-    )
-
 const PROGRAM_RULE_FUNCTION_ELEMENTS = [
     { id: 'd2:ceil( <number> )', displayName: 'd2:ceil( <number> )' },
     { id: 'd2:floor( <number> )', displayName: 'd2:floor( <number> )' },
@@ -981,7 +965,9 @@ const PROGRAM_RULE_OPERATOR_ELEMENTS = [
     { id: '||', displayName: 'OR' },
 ]
 
-const programIndicatorElementTypes: ElementType[] = [
+const programIndicatorElementTypes = (
+    isEventProgram: boolean
+): ElementType[] => [
     {
         type: 'operator',
         name: i18n.t('Operators'),
@@ -991,7 +977,10 @@ const programIndicatorElementTypes: ElementType[] = [
     {
         type: 'variables',
         name: i18n.t('Variables'),
-        elements: PI_VARIABLE_ELEMENTS,
+        elements: filterEnrollmentVariables(
+            PI_VARIABLE_ELEMENTS,
+            isEventProgram
+        ),
         component: DefaultList,
     },
     {
@@ -1011,7 +1000,23 @@ const programIndicatorElementTypes: ElementType[] = [
     },
 ]
 
-const programRuleElementTypes: ElementType[] = [
+const programIndicatorElementTypesCount = (
+    isEventProgram: boolean
+): ElementType[] => {
+    const types = programIndicatorElementTypes(isEventProgram)
+    types[1] = {
+        type: 'variables',
+        name: i18n.t('Variables'),
+        elements: filterEnrollmentVariables(
+            PI_VARIABLE_ELEMENTS_COUNT,
+            isEventProgram
+        ),
+        component: DefaultList,
+    }
+    return types
+}
+
+const programRuleElementTypes = (isEventProgram: boolean): ElementType[] => [
     {
         type: 'operator',
         name: i18n.t('Operators'),
@@ -1021,7 +1026,10 @@ const programRuleElementTypes: ElementType[] = [
     {
         type: 'variables',
         name: i18n.t('Variables'),
-        elements: PROGRAM_RULE_VARIABLE_ELEMENTS,
+        elements: filterEnrollmentVariables(
+            PROGRAM_RULE_VARIABLE_ELEMENTS,
+            isEventProgram
+        ),
         component: DefaultList,
     },
     {
@@ -1037,16 +1045,6 @@ const programRuleElementTypes: ElementType[] = [
     },
 ]
 
-const programIndicatorElementTypesCount: ElementType[] = [
-    ...programIndicatorElementTypes,
-]
-programIndicatorElementTypesCount[1] = {
-    type: 'variables',
-    name: i18n.t('Variables'),
-    elements: PI_VARIABLE_ELEMENTS_COUNT,
-    component: DefaultList,
-}
-
 export const getElementTypes = (
     type: ExpressionBuilderType,
     {
@@ -1058,14 +1056,12 @@ export const getElementTypes = (
     }
 ): ElementType[] => {
     if (type === 'programIndicator') {
-        const elementTypes =
-            aggregationType === 'COUNT'
-                ? programIndicatorElementTypesCount
-                : programIndicatorElementTypes
-        return withFilteredVariables(elementTypes, isEventProgram)
+        return aggregationType === 'COUNT'
+            ? programIndicatorElementTypesCount(isEventProgram)
+            : programIndicatorElementTypes(isEventProgram)
     }
     if (type === 'programRule') {
-        return withFilteredVariables(programRuleElementTypes, isEventProgram)
+        return programRuleElementTypes(isEventProgram)
     }
     if (type === 'indicator') {
         return indicatorElementTypes

--- a/src/components/ExpressionBuilder/VariableSelectionBox.spec.tsx
+++ b/src/components/ExpressionBuilder/VariableSelectionBox.spec.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { Form } from 'react-final-form'
+import { VariableSelectionBox } from './VariableSelectionBox'
+
+const renderVariableSelectionBox = ({
+    programType,
+}: {
+    programType?: string
+}) => {
+    const elementRef = { current: null }
+
+    return render(
+        <Form
+            onSubmit={jest.fn()}
+            render={() => (
+                <VariableSelectionBox
+                    elementRef={elementRef}
+                    clearValidationState={jest.fn()}
+                    programType={programType}
+                    type="programRule"
+                />
+            )}
+        />
+    )
+}
+
+describe('VariableSelectionBox', () => {
+    it('hides variables for event programs', async () => {
+        renderVariableSelectionBox({ programType: 'WITHOUT_REGISTRATION' })
+
+        await userEvent.click(screen.getByText('Variables'))
+
+        expect(screen.queryByText('V{enrollment_date}')).not.toBeInTheDocument()
+        expect(
+            screen.queryByText('V{enrollment_status}')
+        ).not.toBeInTheDocument()
+        expect(screen.queryByText('V{incident_date}')).not.toBeInTheDocument()
+        expect(screen.getByText('V{current_date}')).toBeInTheDocument()
+    })
+
+    it('shows enrollment variables for tracker programs', async () => {
+        renderVariableSelectionBox({ programType: 'WITH_REGISTRATION' })
+
+        await userEvent.click(screen.getByText('Variables'))
+
+        expect(screen.getByText('V{enrollment_date}')).toBeInTheDocument()
+        expect(screen.getByText('V{enrollment_status}')).toBeInTheDocument()
+        expect(screen.getByText('V{incident_date}')).toBeInTheDocument()
+    })
+
+    it('defaults to hiding enrollment variables when programType is not provided', async () => {
+        renderVariableSelectionBox({ programType: undefined })
+
+        await userEvent.click(screen.getByText('Variables'))
+
+        expect(screen.queryByText('V{enrollment_date}')).not.toBeInTheDocument()
+    })
+})

--- a/src/components/ExpressionBuilder/VariableSelectionBox.tsx
+++ b/src/components/ExpressionBuilder/VariableSelectionBox.tsx
@@ -1,16 +1,9 @@
 import { IconChevronDown16, IconChevronRight16 } from '@dhis2/ui'
-import { useQuery } from '@tanstack/react-query'
 import React, { useCallback, useState, RefObject } from 'react'
 import { useField } from 'react-final-form'
-import { useBoundResourceQueryFn } from '../../lib'
 import styles from './ExpressionBuilder.module.css'
 import { ExpressionBuilderType } from './types'
 import { ElementType, getElementTypes } from './ValidationRuleVariables'
-
-type ProgramTypeResponse = {
-    id: string
-    programType?: string
-}
 
 const insertElementNonClosure = ({
     elementText,
@@ -42,11 +35,13 @@ export const VariableSelectionBox = ({
     elementRef,
     clearValidationState,
     programId,
+    programType,
     type,
 }: {
     elementRef: RefObject<HTMLInputElement | HTMLTextAreaElement>
     clearValidationState: () => void
     programId?: string
+    programType?: string
     type: ExpressionBuilderType
 }) => {
     const { input: aggregationTypeInput } = useField<string>(
@@ -54,21 +49,7 @@ export const VariableSelectionBox = ({
         { subscription: { value: true } }
     )
 
-    const queryFn = useBoundResourceQueryFn()
-    const hasVariables = type === 'programIndicator' || type === 'programRule'
-    const programInfo = useQuery({
-        queryKey: [
-            {
-                resource: 'programs',
-                id: programId,
-                params: { fields: ['id', 'programType'] },
-            },
-        ],
-        queryFn: queryFn<ProgramTypeResponse>,
-        enabled: !!programId && hasVariables,
-    })
-    const isEventProgram =
-        programInfo.data?.programType === 'WITHOUT_REGISTRATION'
+    const isEventProgram = programType !== 'WITH_REGISTRATION'
 
     const elementTypes = getElementTypes(type, {
         aggregationType: aggregationTypeInput?.value,

--- a/src/components/ExpressionBuilder/VariableSelectionBox.tsx
+++ b/src/components/ExpressionBuilder/VariableSelectionBox.tsx
@@ -1,9 +1,16 @@
 import { IconChevronDown16, IconChevronRight16 } from '@dhis2/ui'
+import { useQuery } from '@tanstack/react-query'
 import React, { useCallback, useState, RefObject } from 'react'
 import { useField } from 'react-final-form'
+import { useBoundResourceQueryFn } from '../../lib'
 import styles from './ExpressionBuilder.module.css'
 import { ExpressionBuilderType } from './types'
 import { ElementType, getElementTypes } from './ValidationRuleVariables'
+
+type ProgramTypeResponse = {
+    id: string
+    programType?: string
+}
 
 const insertElementNonClosure = ({
     elementText,
@@ -47,8 +54,25 @@ export const VariableSelectionBox = ({
         { subscription: { value: true } }
     )
 
+    const queryFn = useBoundResourceQueryFn()
+    const hasVariables = type === 'programIndicator' || type === 'programRule'
+    const programInfo = useQuery({
+        queryKey: [
+            {
+                resource: 'programs',
+                id: programId,
+                params: { fields: ['id', 'programType'] },
+            },
+        ],
+        queryFn: queryFn<ProgramTypeResponse>,
+        enabled: !!programId && hasVariables,
+    })
+    const isEventProgram =
+        programInfo.data?.programType === 'WITHOUT_REGISTRATION'
+
     const elementTypes = getElementTypes(type, {
         aggregationType: aggregationTypeInput?.value,
+        isEventProgram,
     })
     const [selectedElementType, setSelectedElementType] = useState<
         string | undefined

--- a/src/pages/programDisaggregations/Edit.tsx
+++ b/src/pages/programDisaggregations/Edit.tsx
@@ -35,6 +35,7 @@ const fieldFilters = [
     'name',
     'shortName',
     'code',
+    'programType',
     'categoryMappings',
 ] as const
 
@@ -212,6 +213,9 @@ export const Component = () => {
                                         }
                                         programName={
                                             programQuery?.data?.displayName
+                                        }
+                                        programType={
+                                            programQuery?.data?.programType
                                         }
                                     />
                                     <ProgramDisaggregationFooter

--- a/src/pages/programDisaggregations/form/CategoryMapping.tsx
+++ b/src/pages/programDisaggregations/form/CategoryMapping.tsx
@@ -80,11 +80,13 @@ type CategoryMappingProps = {
     fieldName: string
     categoryOptionArray: CategoryOption[]
     showSoftDelete: boolean
+    programType?: string
 }
 export const CategoryMapping = React.memo(function CategoryMapping({
     fieldName,
     categoryOptionArray,
     showSoftDelete = true,
+    programType,
 }: CategoryMappingProps) {
     const categoryMapping = useField(fieldName)
     const categoryMappingOnChange = categoryMapping?.input?.onChange
@@ -183,6 +185,7 @@ export const CategoryMapping = React.memo(function CategoryMapping({
                     fieldName={fieldName}
                     opt={opt}
                     categoryOptionInformation={categoryOptionInformation}
+                    programType={programType}
                 />
             ))}
         </CategoryMappingWrapper>
@@ -193,10 +196,12 @@ const CategoryMappingInput = ({
     fieldName,
     opt,
     categoryOptionInformation,
+    programType,
 }: {
     fieldName: string
     opt: CategoryOption
     categoryOptionInformation: Record<string, string>
+    programType?: string
 }) => {
     const programId = useParams()?.id
     const expressionSchemaSection = {
@@ -216,6 +221,7 @@ const CategoryMappingInput = ({
                 validationResource="programIndicators/filter/description"
                 clearable={true}
                 programId={programId}
+                programType={programType}
                 type="programIndicator"
                 validateSchemaSection={expressionSchemaSection}
                 validateProperty="expression"

--- a/src/pages/programDisaggregations/form/CategoryMappingSection.tsx
+++ b/src/pages/programDisaggregations/form/CategoryMappingSection.tsx
@@ -195,8 +195,10 @@ const useCategories = ({
 }
 export const CategoryMappingSection = ({
     dataDimensionType,
+    programType,
 }: {
     dataDimensionType: DataDimensionType
+    programType?: string
 }) => {
     const formApi = useForm()
 
@@ -277,6 +279,7 @@ export const CategoryMappingSection = ({
                     <CategoryMappingList
                         key={category.id}
                         category={category}
+                        programType={programType}
                         initiallyExpanded={addedCategories.some(
                             (c) => c.id === category.id
                         )}
@@ -324,10 +327,12 @@ const SuggestedCategory = ({
 type DisaggregationCategoryProps = {
     category: CategoryFromSelect
     initiallyExpanded?: boolean
+    programType?: string
 }
 export const CategoryMappingList = ({
     category,
     initiallyExpanded = false,
+    programType,
 }: DisaggregationCategoryProps) => {
     const array = useFieldArray(`categoryMappings.${category.id}`)
     const { input: categoryMappingsDeleted } =
@@ -407,6 +412,7 @@ export const CategoryMappingList = ({
                         fieldName={fieldName}
                         categoryOptionArray={category.categoryOptions ?? []}
                         showSoftDelete={showSoftDelete}
+                        programType={programType}
                     />
                 </div>
             ))}

--- a/src/pages/programDisaggregations/form/ProgramDisaggregationFormFields.tsx
+++ b/src/pages/programDisaggregations/form/ProgramDisaggregationFormFields.tsx
@@ -14,9 +14,11 @@ import { ProgramIndicatorMappingSection } from './ProgramIndicatorMappingSection
 export const ProgramDisaggregationFormFields = ({
     initialProgramIndicators,
     programName,
+    programType,
 }: {
     initialProgramIndicators: ProgramIndicatorWithMapping[]
     programName?: string
+    programType?: string
 }) => {
     useSyncSelectedSectionWithScroll()
 
@@ -38,6 +40,7 @@ export const ProgramDisaggregationFormFields = ({
                     </StandardFormSectionDescription>
                     <CategoryMappingSection
                         dataDimensionType={'DISAGGREGATION'}
+                        programType={programType}
                     />
                 </SectionedFormSection>
                 <SectionedFormSection name="attributeCategories">
@@ -49,7 +52,10 @@ export const ProgramDisaggregationFormFields = ({
                             'Define expressions to map individual data to category options.'
                         )}
                     </StandardFormSectionDescription>
-                    <CategoryMappingSection dataDimensionType={'ATTRIBUTE'} />
+                    <CategoryMappingSection
+                        dataDimensionType={'ATTRIBUTE'}
+                        programType={programType}
+                    />
                 </SectionedFormSection>
             </SectionedFormSections>
         </div>

--- a/src/pages/programIndicators/form/ProgramIndicatorFormFields.tsx
+++ b/src/pages/programIndicators/form/ProgramIndicatorFormFields.tsx
@@ -193,6 +193,7 @@ export const ProgramIndicatorsFormFields = () => {
                             validationResource="programIndicators/expression/description"
                             clearable={true}
                             programId={programInput?.value?.id}
+                            programType={programInput?.value?.programType}
                             type="programIndicator"
                             validateSchemaSection={section}
                         />
@@ -219,6 +220,7 @@ export const ProgramIndicatorsFormFields = () => {
                             validationResource="programIndicators/filter/description"
                             clearable={true}
                             programId={programInput?.value?.id}
+                            programType={programInput?.value?.programType}
                             type="programIndicator"
                             validateSchemaSection={section}
                         />

--- a/src/pages/programRules/fields/ConditionField.tsx
+++ b/src/pages/programRules/fields/ConditionField.tsx
@@ -6,9 +6,13 @@ import { SCHEMA_SECTIONS } from '../../../lib'
 
 type ConditionFieldProps = Readonly<{
     programId?: string
+    programType?: string
 }>
 
-export function ConditionField({ programId }: ConditionFieldProps) {
+export function ConditionField({
+    programId,
+    programType,
+}: ConditionFieldProps) {
     return (
         <PaddedContainer>
             <ExpressionBuilderEntry
@@ -19,6 +23,7 @@ export function ConditionField({ programId }: ConditionFieldProps) {
                 validationResource="programRules/condition/description"
                 clearable={true}
                 programId={programId}
+                programType={programType}
                 type="programRule"
                 validateSchemaSection={SCHEMA_SECTIONS.programRule}
             />

--- a/src/pages/programRules/fields/ExpressionField.tsx
+++ b/src/pages/programRules/fields/ExpressionField.tsx
@@ -16,6 +16,7 @@ export function ExpressionField({
     fieldName = 'data',
     label,
     programId,
+    programType,
     clearable = true,
     disabled = false,
     required = false,
@@ -23,6 +24,7 @@ export function ExpressionField({
     fieldName?: string
     label: string
     programId?: string
+    programType?: string
     clearable?: boolean
     disabled?: boolean
     required?: boolean
@@ -46,6 +48,7 @@ export function ExpressionField({
                         validationResource="programRuleActions/data/expression/description"
                         clearable={clearable}
                         programId={programId}
+                        programType={programType}
                         type="programRule"
                         validateSchemaSection={programRuleActionSchemaSection}
                         validateProperty={fieldName}

--- a/src/pages/programRules/form/ProgramRuleFormFields.tsx
+++ b/src/pages/programRules/form/ProgramRuleFormFields.tsx
@@ -87,7 +87,10 @@ export const ProgramRuleFormFields = () => {
                     )}
                 </StandardFormSectionDescription>
                 <StandardFormField>
-                    <ConditionField programId={programInput?.value?.id} />
+                    <ConditionField
+                        programId={programInput?.value?.id}
+                        programType={programInput?.value?.programType}
+                    />
                 </StandardFormField>
             </SectionedFormSection>
             <ProgramRuleActionsFormContents

--- a/src/pages/programRules/form/actions/ActionTypeFieldsContent.tsx
+++ b/src/pages/programRules/form/actions/ActionTypeFieldsContent.tsx
@@ -45,13 +45,15 @@ const ACTION_FIELDS_MAP: Partial<Record<string, ActionFieldsRenderer>> = {
 
 export function ActionTypeFieldsContent({
     programId,
+    programType,
     isEdit,
     actionType,
 }: Readonly<{
     programId: string
+    programType?: string
     isEdit: boolean
     actionType: string | undefined
 }>) {
     const render = actionType ? ACTION_FIELDS_MAP[actionType] : undefined
-    return render ? <>{render(programId, isEdit)}</> : null
+    return render ? <>{render(programId, isEdit, programType)}</> : null
 }

--- a/src/pages/programRules/form/actions/ProgramRuleActionForm.tsx
+++ b/src/pages/programRules/form/actions/ProgramRuleActionForm.tsx
@@ -356,6 +356,7 @@ function ProgramRuleActionFormBody({
                 {programId && (
                     <ActionTypeFieldsContent
                         programId={programId}
+                        programType={programType}
                         isEdit={isEdit}
                         actionType={actionType}
                     />

--- a/src/pages/programRules/form/actions/actionContent/assign.tsx
+++ b/src/pages/programRules/form/actions/actionContent/assign.tsx
@@ -8,7 +8,11 @@ import {
     TrackedEntityAttributeField,
 } from '../../../fields'
 
-export function assign(programId: string): ReactNode {
+export function assign(
+    programId: string,
+    isEdit?: boolean,
+    programType?: string
+): ReactNode {
     return (
         <>
             <StandardFormField>
@@ -29,6 +33,7 @@ export function assign(programId: string): ReactNode {
             <StandardFormField>
                 <ExpressionField
                     programId={programId}
+                    programType={programType}
                     label={i18n.t('Expression to evaluate and assign')}
                     clearable={false}
                     required

--- a/src/pages/programRules/form/actions/actionContent/common/messageAction.tsx
+++ b/src/pages/programRules/form/actions/actionContent/common/messageAction.tsx
@@ -10,7 +10,8 @@ import {
 
 export function messageActionFields(
     programId: string,
-    isWarning: boolean
+    isWarning: boolean,
+    programType?: string
 ): ReactNode {
     const dataElementLabel = isWarning
         ? i18n.t('Data element to display warning next to')
@@ -42,6 +43,7 @@ export function messageActionFields(
             <StandardFormField>
                 <ExpressionField
                     programId={programId}
+                    programType={programType}
                     label={i18n.t(
                         'Expression to evaluate and display after static text.'
                     )}

--- a/src/pages/programRules/form/actions/actionContent/displayKeyValuePair.tsx
+++ b/src/pages/programRules/form/actions/actionContent/displayKeyValuePair.tsx
@@ -7,7 +7,11 @@ import {
     LocationField,
 } from '../../../fields'
 
-export function displayKeyValuePair(programId: string): ReactNode {
+export function displayKeyValuePair(
+    programId: string,
+    isEdit?: boolean,
+    programType?: string
+): ReactNode {
     return (
         <>
             <StandardFormField>
@@ -23,6 +27,7 @@ export function displayKeyValuePair(programId: string): ReactNode {
             <StandardFormField>
                 <ExpressionField
                     programId={programId}
+                    programType={programType}
                     label={i18n.t(
                         'Expression to evaluate and display as value.'
                     )}

--- a/src/pages/programRules/form/actions/actionContent/displayText.tsx
+++ b/src/pages/programRules/form/actions/actionContent/displayText.tsx
@@ -7,7 +7,11 @@ import {
     LocationField,
 } from '../../../fields'
 
-export function displayText(programId: string): ReactNode {
+export function displayText(
+    programId: string,
+    isEdit?: boolean,
+    programType?: string
+): ReactNode {
     return (
         <>
             <StandardFormField>
@@ -23,6 +27,7 @@ export function displayText(programId: string): ReactNode {
             <StandardFormField>
                 <ExpressionField
                     programId={programId}
+                    programType={programType}
                     label={i18n.t(
                         'Expression to evaluate and display after static text.'
                     )}

--- a/src/pages/programRules/form/actions/actionContent/errorOnComplete.tsx
+++ b/src/pages/programRules/form/actions/actionContent/errorOnComplete.tsx
@@ -1,4 +1,7 @@
 import { messageActionFields } from './common/messageAction'
 
-export const errorOnComplete = (programId: string) =>
-    messageActionFields(programId, false)
+export const errorOnComplete = (
+    programId: string,
+    isEdit?: boolean,
+    programType?: string
+) => messageActionFields(programId, false, programType)

--- a/src/pages/programRules/form/actions/actionContent/index.ts
+++ b/src/pages/programRules/form/actions/actionContent/index.ts
@@ -2,7 +2,8 @@ import type { ReactNode } from 'react'
 
 export type ActionFieldsRenderer = (
     programId: string,
-    isEdit?: boolean
+    isEdit?: boolean,
+    programType?: string
 ) => ReactNode
 
 export { assign } from './assign'

--- a/src/pages/programRules/form/actions/actionContent/scheduleEvent.tsx
+++ b/src/pages/programRules/form/actions/actionContent/scheduleEvent.tsx
@@ -3,7 +3,11 @@ import React, { ReactNode } from 'react'
 import { StandardFormField } from '../../../../../components'
 import { ExpressionField, ProgramStageSelectField } from '../../../fields'
 
-export function scheduleEvent(programId: string): ReactNode {
+export function scheduleEvent(
+    programId: string,
+    isEdit?: boolean,
+    programType?: string
+): ReactNode {
     return (
         <>
             <StandardFormField>
@@ -12,6 +16,7 @@ export function scheduleEvent(programId: string): ReactNode {
             <StandardFormField>
                 <ExpressionField
                     programId={programId}
+                    programType={programType}
                     label={i18n.t('Program rule variable for scheduled date')}
                     required
                 />

--- a/src/pages/programRules/form/actions/actionContent/scheduleMessage.tsx
+++ b/src/pages/programRules/form/actions/actionContent/scheduleMessage.tsx
@@ -5,7 +5,8 @@ import { ExpressionField, NotificationTemplateField } from '../../../fields'
 
 export function scheduleMessage(
     programId: string,
-    isEdit?: boolean
+    isEdit?: boolean,
+    programType?: string
 ): ReactNode {
     return (
         <>
@@ -19,6 +20,7 @@ export function scheduleMessage(
             <StandardFormField>
                 <ExpressionField
                     programId={programId}
+                    programType={programType}
                     disabled={isEdit}
                     label={i18n.t('Date to send message.')}
                     required

--- a/src/pages/programRules/form/actions/actionContent/showError.tsx
+++ b/src/pages/programRules/form/actions/actionContent/showError.tsx
@@ -1,4 +1,7 @@
 import { messageActionFields } from './common/messageAction'
 
-export const showError = (programId: string) =>
-    messageActionFields(programId, false)
+export const showError = (
+    programId: string,
+    isEdit?: boolean,
+    programType?: string
+) => messageActionFields(programId, false, programType)

--- a/src/pages/programRules/form/actions/actionContent/showWarning.tsx
+++ b/src/pages/programRules/form/actions/actionContent/showWarning.tsx
@@ -1,4 +1,7 @@
 import { messageActionFields } from './common/messageAction'
 
-export const showWarning = (programId: string) =>
-    messageActionFields(programId, true)
+export const showWarning = (
+    programId: string,
+    isEdit?: boolean,
+    programType?: string
+) => messageActionFields(programId, true, programType)

--- a/src/pages/programRules/form/actions/actionContent/warningOnComplete.tsx
+++ b/src/pages/programRules/form/actions/actionContent/warningOnComplete.tsx
@@ -1,4 +1,7 @@
 import { messageActionFields } from './common/messageAction'
 
-export const warningOnComplete = (programId: string) =>
-    messageActionFields(programId, true)
+export const warningOnComplete = (
+    programId: string,
+    isEdit?: boolean,
+    programType?: string
+) => messageActionFields(programId, true, programType)


### PR DESCRIPTION
Fix expression builder:
- For Event Programs, the Variables list hides **Enrollment date**, **Enrollment status**, and **Incident date**. 

[DHIS2-21494](https://dhis2.atlassian.net/browse/DHIS2-21494)

_Variable list (event program)_
<img width="951" height="657" alt="image" src="https://github.com/user-attachments/assets/4705dd98-64c2-417c-af55-37a8acca3260" />

<img width="406" height="452" alt="image" src="https://github.com/user-attachments/assets/8bf8954e-56dd-4010-903d-ca274514cde7" />

_Variable list (tracker program)_
<img width="951" height="545" alt="image" src="https://github.com/user-attachments/assets/463346d9-521e-4113-9cd0-e63a99fee039" />


[DHIS2-21494]: https://dhis2.atlassian.net/browse/DHIS2-21494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ