### PR TITLE
fix: hide tracked entity recipient for event program notifications [DHIS2-21815]

### DIFF
--- a/src/pages/programs/form/programNotification/RecipientSection.tsx
+++ b/src/pages/programs/form/programNotification/RecipientSection.tsx
@@ -18,7 +18,7 @@ import { DeliveryChannelsField } from '../../../dataSetNotificationTemplates/for
 
 const programRecipientOptions = [
     {
-        label: getConstantTranslation('TRACKED_ENTITY_INSTANCE'),
+        label: i18n.t('Tracked entity'),
         value: 'TRACKED_ENTITY_INSTANCE',
     },
     {
@@ -104,14 +104,26 @@ export const RecipientSection = ({
         if (!isStageNotification && recipientInput.value === 'DATA_ELEMENT') {
             form.change('notificationRecipient', undefined)
         }
-    }, [isStageNotification, recipientInput, form])
+        if (
+            !isTrackerProgram &&
+            recipientInput.value === 'TRACKED_ENTITY_INSTANCE'
+        ) {
+            form.change('notificationRecipient', undefined)
+        }
+    }, [isStageNotification, isTrackerProgram, recipientInput, form])
 
     const recipientOptions = useMemo(() => {
-        return isStageNotification || recipientInput.value === 'DATA_ELEMENT'
-            ? programStageRecipientOptions.filter((opt) =>
-                  isTrackerProgram ? true : opt.value !== 'PROGRAM_ATTRIBUTE'
-              )
-            : programRecipientOptions
+        const baseOptions =
+            isStageNotification || recipientInput.value === 'DATA_ELEMENT'
+                ? programStageRecipientOptions
+                : programRecipientOptions
+
+        return baseOptions.filter((opt) =>
+            isTrackerProgram
+                ? true
+                : opt.value !== 'PROGRAM_ATTRIBUTE' &&
+                  opt.value !== 'TRACKED_ENTITY_INSTANCE'
+        )
     }, [isStageNotification, recipientInput.value, isTrackerProgram])
 
     return (


### PR DESCRIPTION
## Description

In **Programs → Notifications → Recipient type**, the recipient `TRACKED_ENTITY_INSTANCE` was offered for **event programs** (`WITHOUT_REGISTRATION`), which have no tracked entities, so the option is meaningless there.

This PR:
- **Hides** the tracked entity recipient option for event programs (it remains available for tracker programs).
- **Relabels** the option from "Tracked entity instance" to **"Tracked entity"** for tracker program notifications (modern terminology).
- Clears a stale stored value on load, mirroring the existing `DATA_ELEMENT` guard, so an event-program template that previously stored a TEI recipient no longer shows a blank/invalid select.

All changes are confined to `src/pages/programs/form/programNotification/RecipientSection.tsx`. No schema, query, or type changes. `"Tracked entity"` already exists in `i18n/en.pot`, so no new translation string is introduced.

## Jira

https://dhis2.atlassian.net/browse/DHIS2-21815

## How to test

1. **Event program** → Notifications → new/edit → Recipient type: "Tracked entity" is **absent**; other options present.
2. **Tracker program** → Notifications → Recipient type: option present, labelled **"Tracked entity"**; selecting it still shows the delivery-channel field.

AI Assisted