### PR TITLE
fix: hide tracked entity recipient for event program notifications [DHIS2-21815]

### DIFF
--- a/src/pages/programs/form/programNotification/RecipientSection.spec.tsx
+++ b/src/pages/programs/form/programNotification/RecipientSection.spec.tsx
@@ -1,0 +1,127 @@
+import { render, waitFor } from '@testing-library/react'
+import React from 'react'
+import { Form } from 'react-final-form'
+import { ComponentWithProvider } from '../../../../testUtils/TestComponentWithRouter'
+import { uiActions } from '../../../../testUtils/uiActions'
+import { RecipientSection } from './RecipientSection'
+
+const programsResolver = () =>
+    Promise.resolve({
+        programs: [
+            {
+                id: 'program-id',
+                displayName: 'Test program',
+                programTrackedEntityAttributes: [],
+            },
+        ],
+        pager: { page: 1, total: 1, pageSize: 50, pageCount: 1 },
+    })
+
+const renderRecipientSection = ({
+    isTrackerProgram,
+    isStageNotification = false,
+    initialValues = {},
+}: {
+    isTrackerProgram: boolean
+    isStageNotification?: boolean
+    initialValues?: Record<string, unknown>
+}) => {
+    const screen = render(
+        <ComponentWithProvider
+            dataForCustomProvider={{ programs: programsResolver }}
+        >
+            <Form onSubmit={() => undefined} initialValues={initialValues}>
+                {() => (
+                    <RecipientSection
+                        isStageNotification={isStageNotification}
+                        isTrackerProgram={isTrackerProgram}
+                    />
+                )}
+            </Form>
+        </ComponentWithProvider>
+    )
+
+    const openRecipientOptions = async () =>
+        (
+            await uiActions.openSingleSelect(
+                screen.getByTestId('formfields-notification-recipient'),
+                screen
+            )
+        ).map((option) => option.textContent)
+
+    return { ...screen, openRecipientOptions }
+}
+
+describe('<RecipientSection />', () => {
+    describe('recipient option visibility', () => {
+        it('hides "Tracked entity" and "Program attribute" for an event program', async () => {
+            const { openRecipientOptions } = renderRecipientSection({
+                isTrackerProgram: false,
+            })
+
+            const options = await openRecipientOptions()
+
+            expect(options).not.toContain('Tracked entity')
+            expect(options).not.toContain('Program attribute')
+            expect(options).toContain('User group')
+        })
+
+        it('shows "Tracked entity" and "Program attribute" for a tracker program', async () => {
+            const { openRecipientOptions } = renderRecipientSection({
+                isTrackerProgram: true,
+            })
+
+            const options = await openRecipientOptions()
+
+            expect(options).toContain('Tracked entity')
+            expect(options).toContain('Program attribute')
+        })
+    })
+
+    describe('clearing a stale stored recipient on load', () => {
+        it('clears a stored TRACKED_ENTITY_INSTANCE recipient for an event program', async () => {
+            const { queryByTestId } = renderRecipientSection({
+                isTrackerProgram: false,
+                initialValues: {
+                    notificationRecipient: 'TRACKED_ENTITY_INSTANCE',
+                },
+            })
+
+            // Delivery channels only render while a tracked-entity/org-unit
+            // recipient is selected, so their removal proves the stale value
+            // was cleared.
+            await waitFor(() =>
+                expect(
+                    queryByTestId('formfields-sendSms')
+                ).not.toBeInTheDocument()
+            )
+        })
+
+        it('clears a stored PROGRAM_ATTRIBUTE recipient for an event program', async () => {
+            const { queryByTestId } = renderRecipientSection({
+                isTrackerProgram: false,
+                initialValues: {
+                    notificationRecipient: 'PROGRAM_ATTRIBUTE',
+                    program: { id: 'program-id' },
+                },
+            })
+
+            await waitFor(() =>
+                expect(
+                    queryByTestId('formfields-recipientProgramAttribute')
+                ).not.toBeInTheDocument()
+            )
+        })
+
+        it('keeps a stored TRACKED_ENTITY_INSTANCE recipient for a tracker program', async () => {
+            const { findByTestId } = renderRecipientSection({
+                isTrackerProgram: true,
+                initialValues: {
+                    notificationRecipient: 'TRACKED_ENTITY_INSTANCE',
+                },
+            })
+
+            expect(await findByTestId('formfields-sendSms')).toBeInTheDocument()
+        })
+    })
+})

--- a/src/pages/programs/form/programNotification/RecipientSection.tsx
+++ b/src/pages/programs/form/programNotification/RecipientSection.tsx
@@ -106,11 +106,12 @@ export const RecipientSection = ({
         }
         if (
             !isTrackerProgram &&
-            recipientInput.value === 'TRACKED_ENTITY_INSTANCE'
+            (recipientInput.value === 'TRACKED_ENTITY_INSTANCE' ||
+                recipientInput.value === 'PROGRAM_ATTRIBUTE')
         ) {
             form.change('notificationRecipient', undefined)
         }
-    }, [isStageNotification, isTrackerProgram, recipientInput, form])
+    }, [isStageNotification, isTrackerProgram, recipientInput.value, form])
 
     const recipientOptions = useMemo(() => {
         const baseOptions =
@@ -118,8 +119,12 @@ export const RecipientSection = ({
                 ? programStageRecipientOptions
                 : programRecipientOptions
 
+        // Keep the currently-selected value as an option even when it would
+        // otherwise be hidden: a stale stored value is cleared by the effect
+        // above only after this render, and @dhis2/ui throws if the select is
+        // handed a value with no matching option.
         return baseOptions.filter((opt) =>
-            isTrackerProgram
+            isTrackerProgram || opt.value === recipientInput.value
                 ? true
                 : opt.value !== 'PROGRAM_ATTRIBUTE' &&
                   opt.value !== 'TRACKED_ENTITY_INSTANCE'

--- a/src/pages/programs/form/programNotification/RecipientSection.tsx
+++ b/src/pages/programs/form/programNotification/RecipientSection.tsx
@@ -18,7 +18,7 @@ import { DeliveryChannelsField } from '../../../dataSetNotificationTemplates/for
 
 const programRecipientOptions = [
     {
-        label: getConstantTranslation('TRACKED_ENTITY_INSTANCE'),
+        label: i18n.t('Tracked entity'),
         value: 'TRACKED_ENTITY_INSTANCE',
     },
     {
@@ -104,14 +104,26 @@ export const RecipientSection = ({
         if (!isStageNotification && recipientInput.value === 'DATA_ELEMENT') {
             form.change('notificationRecipient', undefined)
         }
-    }, [isStageNotification, recipientInput, form])
+        if (
+            !isTrackerProgram &&
+            recipientInput.value === 'TRACKED_ENTITY_INSTANCE'
+        ) {
+            form.change('notificationRecipient', undefined)
+        }
+    }, [isStageNotification, isTrackerProgram, recipientInput, form])
 
     const recipientOptions = useMemo(() => {
-        return isStageNotification || recipientInput.value === 'DATA_ELEMENT'
-            ? programStageRecipientOptions.filter((opt) =>
-                  isTrackerProgram ? true : opt.value !== 'PROGRAM_ATTRIBUTE'
-              )
-            : programRecipientOptions
+        const baseOptions =
+            isStageNotification || recipientInput.value === 'DATA_ELEMENT'
+                ? programStageRecipientOptions
+                : programRecipientOptions
+
+        return baseOptions.filter((opt) =>
+            isTrackerProgram
+                ? true
+                : opt.value !== 'PROGRAM_ATTRIBUTE' &&
+                  opt.value !== 'TRACKED_ENTITY_INSTANCE'
+        )
     }, [isStageNotification, recipientInput.value, isTrackerProgram])
 
     return (


### PR DESCRIPTION
## Description

In **Programs → Notifications → Recipient type**, the recipient `TRACKED_ENTITY_INSTANCE` was offered for **event programs** (`WITHOUT_REGISTRATION`), which have no tracked entities, so the option is meaningless there.

This PR:
- **Hides** the tracked entity recipient option for event programs (it remains available for tracker programs).
- **Relabels** the option from "Tracked entity instance" to **"Tracked entity"** for tracker program notifications (modern terminology).
- Clears a stale stored value on load, mirroring the existing `DATA_ELEMENT` guard, so an event-program template that previously stored a TEI recipient no longer shows a blank/invalid select.

All changes are confined to `src/pages/programs/form/programNotification/RecipientSection.tsx`. No schema, query, or type changes. `"Tracked entity"` already exists in `i18n/en.pot`, so no new translation string is introduced.

## Jira

https://dhis2.atlassian.net/browse/DHIS2-21815

## How to test

1. **Event program** → Notifications → new/edit → Recipient type: "Tracked entity" is **absent**; other options present.
2. **Tracker program** → Notifications → Recipient type: option present, labelled **"Tracked entity"**; selecting it still shows the delivery-channel field.

AI Assisted