### PR TITLE
fix: predictor edit issue

### DIFF
--- a/src/pages/predictors/Edit.tsx
+++ b/src/pages/predictors/Edit.tsx
@@ -68,7 +68,7 @@ export const Component = () => {
             predictorQuery.data && {
                 ...predictorQuery.data,
                 outputCombo: isDefaultOutputComboCoC
-                    ? {}
+                    ? undefined
                     : predictorQuery?.data?.outputCombo,
             }
         )

--- a/src/pages/predictors/Form.spec.tsx
+++ b/src/pages/predictors/Form.spec.tsx
@@ -732,6 +732,7 @@ describe('Predictors form tests', () => {
                     customTestData = {},
                     matchingExistingElementFilter = undefined,
                     useDefaultCCOutputDE = false,
+                    useDefaultCategoryOptionCombo = false,
                 } = {}
             ) => {
                 const attributes = [testCustomAttribute()]
@@ -771,7 +772,15 @@ describe('Predictors form tests', () => {
                     ? dataElementWithDefaultCategoryCombo
                     : dataElementWithCategoryCombo
                 if (!useDefaultCCOutputDE) {
-                    predictor.outputCombo = categoryOptionCombos[0]
+                    predictor.outputCombo = useDefaultCategoryOptionCombo
+                        ? testCategoryOptionCombo({
+                              categoryCombo: {
+                                  id: randomDhis2Id(),
+                                  isDefault: true,
+                              },
+                              isDefault: true,
+                          })
+                        : categoryOptionCombos[0]
                 }
                 predictor.organisationUnitLevels = organisationUnitLevels
                 predictor.periodType = periodTypes[1] as Predictor.periodType
@@ -1013,6 +1022,33 @@ describe('Predictors form tests', () => {
                 expect(
                     screen.queryByTestId('formfields-outputCombo')
                 ).not.toBeInTheDocument()
+            })
+        })
+
+        it('does not show a required error for the output combo field when it is the default COC', async () => {
+            const { screen, predictor } = await renderForm({
+                useDefaultCategoryOptionCombo: true,
+            })
+
+            expect(
+                screen.queryByTestId('formfields-outputCombo-validation')
+            ).not.toBeInTheDocument()
+
+            const newName = faker.internet.userName()
+            await uiActions.enterName(newName, screen)
+            await uiActions.submitForm(screen)
+
+            expect(updateMock).toHaveBeenCalledWith({
+                data: [
+                    {
+                        op: 'replace',
+                        path: '/name',
+                        value: newName,
+                    },
+                ],
+                id: predictor.id,
+                params: undefined,
+                resource: 'predictors',
             })
         })
 


### PR DESCRIPTION
This fixes an issue with predictor validation on edit. In order for the form to display correctly if outputCombo is default, we need to remove the actual value `HllvX50cXC0` in edit view. I replaced with `{}`, but this should have been `undefined` because zod validator does not consider this as empty and then says the form is required (it should probably be saying something other than "required" as it is marked as optional in the schema, but that is a separate issue)

+ there is a test to cover this scenario added by Claude